### PR TITLE
Show users with no roles

### DIFF
--- a/sciencelabs/static/assets/css/sciencelabs.css
+++ b/sciencelabs/static/assets/css/sciencelabs.css
@@ -207,7 +207,7 @@ table {
     border: 1px solid #ddd !important;
 }
 
-td.year-range{
+td.no-space{
     white-space: nowrap;
 }
 

--- a/sciencelabs/templates/reports/cumulative.html
+++ b/sciencelabs/templates/reports/cumulative.html
@@ -64,7 +64,7 @@
         {% for row in cumulative_list[1:(cumulative_list|length - 1)] %}
             <tr>
                 {% set year = row[0][:4] %}
-                <td class="year-range">{{ row[0] }}</td>
+                <td class="no-space">{{ row[0] }}</td>
                 <td>
                     {% if row[1] <= 0 %}
                         {{ row[1] }}

--- a/sciencelabs/templates/reports/enrollment.html
+++ b/sciencelabs/templates/reports/enrollment.html
@@ -27,7 +27,7 @@
                 <tbody>
                     {% for semester, attendance_info in semesters_and_attendance.items() %}
                         <tr>
-                            <td class="year-range">{{ semester.term }} {{ semester.year }}</td>
+                            <td class="no-space">{{ semester.term }} {{ semester.year }}</td>
                             <td>{{ attendance_info['totalAttendance'] }}</td>
                             <td>{{ attendance_info['uniqueAttendance'] }}</td>
                             <td>{{ attendance_info['enrolled'] }}</td>

--- a/sciencelabs/templates/users/users.html
+++ b/sciencelabs/templates/users/users.html
@@ -15,7 +15,6 @@
                 <table id="table"  class="table table-striped table-bordered">
                     <thead>
                         <tr>
-                            <th>Role Sort</th>
                             <th data-toggle="tooltip" data-placement="top" title="User Last Name">Last</th>
                             <th data-toggle="tooltip" data-placement="top" title="User First Name">First</th>
                             <th data-toggle="tooltip" data-placement="top" title="User Email">Email</th>
@@ -25,29 +24,26 @@
                             <th>✓</th>
                         </tr>
                         <tr>
-                            <th colspan="6"></th>
+                            <th colspan="5"></th>
                             <th colspan="2">
                                 <button id="deactivate-users" type="button" class="btn btn-primary hover-bright">Deactivate</button>
                             </th>
                         </tr>
                     </thead>
                     <tbody>
-                        {% for user, role in users_info %}
+                        {% for user, roles in users_info.items() %}
                             <tr>
-                                <td>
-                                    {{ role.sort }}
-                                </td>
-                                <td>
+                                <td class="no-space">
                                     {{ user.lastName }}
                                 </td>
-                                <td>
+                                <td class="no-space">
                                     {{ user.firstName }}
                                 </td>
-                                <td>
+                                <td class="no-space">
                                     {{ user.email }}
                                 </td>
                                 <td>
-                                    {{ role.name }}
+                                    {{ roles }}
                                 </td>
                                 <td>
                                     {% if session['ADMIN-VIEWER'] or user.username == session['USERNAME'] %}
@@ -111,10 +107,9 @@
             });
 
             var table = $('#table').DataTable( {
-                "aaSorting": [[0, 'desc'], [1, 'asc']],
+                "aaSorting": [[0, 'asc']],
 
                 "aoColumns": [
-                    { "orderSequence": [ null ] },
                     { "orderSequence": [ "asc", "desc" ] },
                     { "orderSequence": [ "asc", "desc" ] },
                     { "orderSequence": [ "asc", "desc" ] },
@@ -122,10 +117,6 @@
                     { "orderSequence": [ null ] },
                     { "orderSequence": [ null ] },
                     { "orderSequence": [ null ] },
-                ],
-
-                "columnDefs": [
-                    {"visible": false, "targets": 0}
                 ],
 
                 "bPaginate": false,

--- a/sciencelabs/users/__init__.py
+++ b/sciencelabs/users/__init__.py
@@ -26,7 +26,13 @@ class UsersView(FlaskView):
     def index(self):
         self.slc.check_roles_and_route(['Administrator'])
 
-        users_info = self.user.get_user_info()
+        active_users = self.user.get_all_current_users()
+        users_info = {}
+        for user in active_users:
+            user_roles = self.user.get_user_roles(user.id)
+            role_names = [role.name for role in user_roles]
+            roles = ", ".join(role_names) if role_names else ''
+            users_info[user] = roles
         return render_template('users/users.html', **locals())
 
     @route('/search')

--- a/sciencelabs/users/__init__.py
+++ b/sciencelabs/users/__init__.py
@@ -72,7 +72,8 @@ class UsersView(FlaskView):
         if existing_user:  # User exists in system
             if existing_user.deletedAt:  # Has been deactivated in the past
                 self.user.activate_existing_user(username)
-                message = "This user has been deactivated in the past, but now they are reactivated with their same roles."
+                self.slc.set_alert('success', 'This user has been activated successfully! You can now edit their roles here.')
+                return redirect(url_for('UsersView:edit_user', user_id=existing_user.id))
             else:  # Currently active
                 message = "This user already exists in the system and is activated."
         return render_template('users/select_user_roles.html', **locals())


### PR DESCRIPTION
Users with no roles will now be shown. In combination with this I think it would be a good idea to soft delete all users with no roles. The one downside for this is when we tell Vicki she will have to add the tutors to the system again and then add the tutor role for them, but I don't think there's any way around that.

I tested this locally a bunch.