### PR TITLE
Term startup fixes

### DIFF
--- a/sciencelabs/__init__.py
+++ b/sciencelabs/__init__.py
@@ -15,9 +15,9 @@ from sciencelabs.db_repository import db_session
 from sciencelabs.db_repository.user_functions import User
 from sciencelabs.db_repository.schedule_functions import Schedule
 
-# sentry = Sentry(app, dsn=app.config['SENTRY_URL'], logging=True, level=logging.INFO)
-# if app.config['ENVIRON'] == 'prod':
-#     from sciencelabs import error
+sentry = Sentry(app, dsn=app.config['SENTRY_URL'], logging=True, level=logging.INFO)
+if app.config['ENVIRON'] == 'prod':
+    from sciencelabs import error
 
 from sciencelabs.views import View
 from sciencelabs.cron import CronView

--- a/sciencelabs/__init__.py
+++ b/sciencelabs/__init__.py
@@ -15,9 +15,9 @@ from sciencelabs.db_repository import db_session
 from sciencelabs.db_repository.user_functions import User
 from sciencelabs.db_repository.schedule_functions import Schedule
 
-sentry = Sentry(app, dsn=app.config['SENTRY_URL'], logging=True, level=logging.INFO)
-if app.config['ENVIRON'] == 'prod':
-    from sciencelabs import error
+# sentry = Sentry(app, dsn=app.config['SENTRY_URL'], logging=True, level=logging.INFO)
+# if app.config['ENVIRON'] == 'prod':
+#     from sciencelabs import error
 
 from sciencelabs.views import View
 from sciencelabs.cron import CronView

--- a/sciencelabs/course/__init__.py
+++ b/sciencelabs/course/__init__.py
@@ -55,14 +55,14 @@ class CourseView(FlaskView):
                 course_code = course.split(" ")[0]
                 number = self._dept_length(course_code)
                 cc_info = self.wsapi.validate_course(course_code[:number], course_code[number:])
-                course_info = self.wsapi.get_course_info(course[:number], course[number:])
+                course_info = self.wsapi.get_course_info(course_code[:number], course_code[number:])
                 if cc_info and course_info:
                     self._handle_coursecode(cc_info['0'])
                     for info in course_info:
                         self._handle_course(course_info[info])
             self.slc.set_alert('success', 'Courses Submitted Successfully!')
         except Exception as error:
-            self.slc.set_alert('danger', 'Failed to add courses: ' + str(error))
+            self.slc.set_alert('danger', 'Course Submission Failed: ' + error)
 
         return redirect(url_for('CourseView:index'))
 

--- a/sciencelabs/db_repository/course_functions.py
+++ b/sciencelabs/db_repository/course_functions.py
@@ -3,7 +3,8 @@ from sqlalchemy import orm
 from flask import session as flask_session
 from sciencelabs.db_repository import db_session
 from sciencelabs.db_repository.db_tables import User_Table, Course_Table, CourseProfessors_Table, Semester_Table, \
-    Session_Table, CourseCode_Table, SessionCourses_Table, StudentSession_Table, CourseViewer_Table
+    Session_Table, CourseCode_Table, SessionCourses_Table, StudentSession_Table, CourseViewer_Table, \
+    ScheduleCourseCodes_Table, SessionCourseCodes_Table
 
 
 class Course:
@@ -309,3 +310,19 @@ class Course:
             enrolled = enrolled + course.num_attendees if course.num_attendees else enrolled
         return enrolled
 
+    def get_schedule_course_ids(self, schedule_id):
+        schedule_courses = db_session.query(ScheduleCourseCodes_Table)\
+            .filter(ScheduleCourseCodes_Table.schedule_id == schedule_id)\
+            .all()
+        schedule_course_ids = []
+        for course in schedule_courses:
+            schedule_course_ids.append(course.coursecode_id)
+        return schedule_course_ids
+
+    def get_session_course_ids(self, session_id):
+        session_courses = db_session.query(SessionCourseCodes_Table) \
+            .filter(SessionCourseCodes_Table.session_id == session_id).all()
+        session_course_ids = []
+        for course in session_courses:
+            session_course_ids.append(course.coursecode_id)
+        return session_course_ids

--- a/sciencelabs/db_repository/course_functions.py
+++ b/sciencelabs/db_repository/course_functions.py
@@ -170,6 +170,7 @@ class Course:
         for semesters in semester_list:
             if semesters['year'] == year and semesters['term'] == term:
                 semester_id = semesters['id']
+                break
         try:
             course = db_session.query(Course_Table)\
                 .filter(semester_id == Course_Table.semester_id)\
@@ -218,6 +219,7 @@ class Course:
         for semesters in semester_list:
             if semesters['year'] == int(year) and semesters['term'] == term:
                 semester_id = semesters['id']
+                break
 
         new_course = Course_Table(semester_id=semester_id, begin_date=begin_date,
                                   begin_time=begin_time, course_num=c_info['cNumber'],

--- a/sciencelabs/db_repository/db_tables.py
+++ b/sciencelabs/db_repository/db_tables.py
@@ -56,7 +56,7 @@ class Role_Table(base):
 class ScheduleCourseCodes_Table(base):
     __tablename__ = 'ScheduleCourseCodes'
     schedule_id = Column(Integer, primary_key=True)
-    coursecode_id = Column(Integer)
+    coursecode_id = Column(Integer, primary_key=True)
 
 
 class Schedule_Table(base):
@@ -84,13 +84,13 @@ class Semester_Table(base):
 class SessionCourseCodes_Table(base):
     __tablename__ = 'SessionCourseCodes'
     session_id = Column(Integer, primary_key=True)
-    coursecode_id = Column(Integer)
+    coursecode_id = Column(Integer, primary_key=True)
 
 
 class SessionCourses_Table(base):
     __tablename__ = 'SessionCourses'
     studentsession_id = Column(Integer, primary_key=True)
-    course_id = Column(Integer)
+    course_id = Column(Integer, primary_key=True)
 
 
 class Session_Table(base):

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -531,35 +531,6 @@ class User:
                 student.deletedAt = datetime.now()
         db_session.commit()
 
-    def demote_tutors(self):
-        # This logic below updates lead tutor role to be a tutor role, if a lead tutor isn't also assigned the tutor role
-        leads = db_session.query(User_Table) \
-            .filter(User_Table.id == user_role_Table.user_id) \
-            .filter(user_role_Table.role_id == Role_Table.id) \
-            .filter(Role_Table.name == 'Lead Tutor') \
-            .filter(User_Table.deletedAt == None) \
-            .all()
-        for lead in leads:
-            roles = db_session.query(user_role_Table.user_id, user_role_Table.role_id).filter(
-                user_role_Table.user_id == lead.id).all()
-            role_list = []
-            for role in roles:
-                role_list.append(role[1])
-            if 40004 not in role_list:  # checks if tutor role is in the current list
-                db_session.query(user_role_Table).filter(user_role_Table.user_id == lead.id).filter(
-                    user_role_Table.role_id == 40003).update({'role_id': 40004})
-                db_session.commit()
-
-        # This logic below deletes all the Lead Tutors
-        lead_roles = db_session.query(user_role_Table) \
-            .filter(User_Table.id == user_role_Table.user_id) \
-            .filter(user_role_Table.role_id == Role_Table.id) \
-            .filter(Role_Table.name == 'Lead Tutor') \
-            .all()
-        for lead_role in lead_roles:
-            db_session.delete(lead_role)
-        db_session.commit()
-
     def check_or_create_student_role(self, student_id):
         if not self.user_is_student(student_id):
             student_role = self.get_role_by_name('Student')

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -196,6 +196,12 @@ class User:
         return db_session.query(Semester_Table).filter(Semester_Table.active == 1).one()
 
     def create_user(self, first_name, last_name, username, send_email):
+        existing_user = self.get_user_by_username(username)
+        if existing_user:
+            if existing_user.deletedAt:
+                existing_user.deletedAt = None
+                db_session.commit()
+            return existing_user
         new_user = User_Table(username=username, password=None, firstName=first_name, lastName=last_name,
                               email='{0}@bethel.edu'.format(username), send_email=send_email, deletedAt=None)
         db_session.add(new_user)

--- a/sciencelabs/schedule/__init__.py
+++ b/sciencelabs/schedule/__init__.py
@@ -45,6 +45,7 @@ class ScheduleView(FlaskView):
         active_semester = self.schedule.get_active_semester()
         schedule = self.schedule.get_schedule(schedule_id)
         course_list = self.course.get_semester_courses(active_semester.id)
+        schedule_course_ids = self.course.get_schedule_course_ids(schedule_id)
         lead_ids = self.schedule.get_scheduled_lead_ids(schedule_id)
         tutor_ids = self.schedule.get_scheduled_tutor_ids(schedule_id)
         lead_list = self.schedule.get_registered_leads()  # used for adding tutors to session

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -83,7 +83,7 @@ class SessionView(FlaskView):
         for student in session_students:
             students_and_courses[student] = self.session.get_student_session_courses(session_id, student.id)
         course_list = self.course.get_semester_courses(flask_session['SELECTED-SEMESTER'])
-        session_courses = self.session.get_session_courses(session_id)
+        session_course_ids = self.course.get_session_course_ids(session_id)
         return render_template('sessions/edit_session.html', **locals())
 
     @route('/attendance/edit/<int:student_id>/<int:session_id>')

--- a/sciencelabs/templates/macros/macros.html
+++ b/sciencelabs/templates/macros/macros.html
@@ -1,4 +1,4 @@
-{% macro select_courses(course_list, selected_course_ids) %}
+{% macro select_courses(course_list, selected_course_ids, create_page) %}
     <div class="form-row">
         <div class="form-group col-md-12">
             <button type="button" class="all blue btn btn-primary" id="all-courses">Select No Courses</button>
@@ -9,7 +9,7 @@
             {% for course in course_list %}
                 <div class="custom-control custom-checkbox display-inl-b">
                     <input name="courses" type="checkbox" class="custom-control-input" id="{{ course.courseName }}" value="{{ course.id }}"
-                            {{ 'checked' if course.id in selected_course_ids or selected_course_ids == 'all' }}>
+                            {{ 'checked' if course.id in selected_course_ids or create_page }}>
                     <label class="custom-control-label" for="{{ course.courseName }}">
                         {{ course.dept }}{{ course.course_num }} ({{ course.courseName }})</label>
                 </div>

--- a/sciencelabs/templates/macros/macros.html
+++ b/sciencelabs/templates/macros/macros.html
@@ -1,4 +1,4 @@
-{% macro select_courses(course_list) %}
+{% macro select_courses(course_list, selected_course_ids) %}
     <div class="form-row">
         <div class="form-group col-md-12">
             <button type="button" class="all blue btn btn-primary" id="all-courses">Select No Courses</button>
@@ -8,7 +8,8 @@
         <div class="form-group col-md-12">
             {% for course in course_list %}
                 <div class="custom-control custom-checkbox display-inl-b">
-                    <input name="courses" type="checkbox" class="custom-control-input" id="{{ course.courseName }}" value="{{ course.id }}" checked>
+                    <input name="courses" type="checkbox" class="custom-control-input" id="{{ course.courseName }}" value="{{ course.id }}"
+                            {{ 'checked' if course.id in selected_course_ids or not selected_course_ids }}>
                     <label class="custom-control-label" for="{{ course.courseName }}">
                         {{ course.dept }}{{ course.course_num }} ({{ course.courseName }})</label>
                 </div>

--- a/sciencelabs/templates/macros/macros.html
+++ b/sciencelabs/templates/macros/macros.html
@@ -9,7 +9,7 @@
             {% for course in course_list %}
                 <div class="custom-control custom-checkbox display-inl-b">
                     <input name="courses" type="checkbox" class="custom-control-input" id="{{ course.courseName }}" value="{{ course.id }}"
-                            {{ 'checked' if course.id in selected_course_ids or not selected_course_ids }}>
+                            {{ 'checked' if course.id in selected_course_ids or selected_course_ids == 'all' }}>
                     <label class="custom-control-label" for="{{ course.courseName }}">
                         {{ course.dept }}{{ course.course_num }} ({{ course.courseName }})</label>
                 </div>

--- a/sciencelabs/templates/schedule/create_new_schedule.html
+++ b/sciencelabs/templates/schedule/create_new_schedule.html
@@ -67,7 +67,7 @@
                         </select>
                     </div>
                 </div>
-                {{ macros.select_courses(course_list) }}
+                {{ macros.select_courses(course_list, None) }}
                 <div class="form-row">
                     <div class="form-group">
                         <button type="submit" class="btn blue btn-primary" id="save-schedule">Save</button>

--- a/sciencelabs/templates/schedule/create_new_schedule.html
+++ b/sciencelabs/templates/schedule/create_new_schedule.html
@@ -67,7 +67,7 @@
                         </select>
                     </div>
                 </div>
-                {{ macros.select_courses(course_list, 'all') }}
+                {{ macros.select_courses(course_list, [], True) }}
                 <div class="form-row">
                     <div class="form-group">
                         <button type="submit" class="btn blue btn-primary" id="save-schedule">Save</button>

--- a/sciencelabs/templates/schedule/create_new_schedule.html
+++ b/sciencelabs/templates/schedule/create_new_schedule.html
@@ -67,7 +67,7 @@
                         </select>
                     </div>
                 </div>
-                {{ macros.select_courses(course_list, None) }}
+                {{ macros.select_courses(course_list, 'all') }}
                 <div class="form-row">
                     <div class="form-group">
                         <button type="submit" class="btn blue btn-primary" id="save-schedule">Save</button>

--- a/sciencelabs/templates/schedule/edit_schedule.html
+++ b/sciencelabs/templates/schedule/edit_schedule.html
@@ -72,7 +72,7 @@
                         </select>
                     </div>
                  </div>
-                {{ macros.select_courses(course_list, schedule_course_ids) }}
+                {{ macros.select_courses(course_list, schedule_course_ids, False) }}
                 <div class="form-row">
                     <div class="form-group">
                         <button type="submit" class="btn blue btn-primary" id="save-schedule">Save</button>

--- a/sciencelabs/templates/schedule/edit_schedule.html
+++ b/sciencelabs/templates/schedule/edit_schedule.html
@@ -72,7 +72,7 @@
                         </select>
                     </div>
                  </div>
-                {{ macros.select_courses(course_list) }}
+                {{ macros.select_courses(course_list, schedule_course_ids) }}
                 <div class="form-row">
                     <div class="form-group">
                         <button type="submit" class="btn blue btn-primary" id="save-schedule">Save</button>

--- a/sciencelabs/templates/sessions/create_session.html
+++ b/sciencelabs/templates/sessions/create_session.html
@@ -80,7 +80,7 @@
                         <input type="time" class="form-control chosen-container chosen-format" id="actual-end" name="actual-end">
                     </div>
                 </div>
-                {{ macros.select_courses(course_list) }}
+                {{ macros.select_courses(course_list, None) }}
                 <div class="form-row">
                     <div class="form-group col-md-12">
                         <label for="comments">Comments</label>

--- a/sciencelabs/templates/sessions/create_session.html
+++ b/sciencelabs/templates/sessions/create_session.html
@@ -80,7 +80,7 @@
                         <input type="time" class="form-control chosen-container chosen-format" id="actual-end" name="actual-end">
                     </div>
                 </div>
-                {{ macros.select_courses(course_list, 'all') }}
+                {{ macros.select_courses(course_list, [], True) }}
                 <div class="form-row">
                     <div class="form-group col-md-12">
                         <label for="comments">Comments</label>

--- a/sciencelabs/templates/sessions/create_session.html
+++ b/sciencelabs/templates/sessions/create_session.html
@@ -80,7 +80,7 @@
                         <input type="time" class="form-control chosen-container chosen-format" id="actual-end" name="actual-end">
                     </div>
                 </div>
-                {{ macros.select_courses(course_list, None) }}
+                {{ macros.select_courses(course_list, 'all') }}
                 <div class="form-row">
                     <div class="form-group col-md-12">
                         <label for="comments">Comments</label>

--- a/sciencelabs/templates/sessions/edit_session.html
+++ b/sciencelabs/templates/sessions/edit_session.html
@@ -87,7 +87,7 @@
                        value="{{ session_info.endTime|datetimeformat('%H:%M') }}">
             </div>
         </div>
-        {{ macros.select_courses(course_list, session_course_ids) }}
+        {{ macros.select_courses(course_list, session_course_ids, False) }}
         <div class="form-row">
             <div class="form-group col-md-12">
                 <label for="comments">Comments</label>

--- a/sciencelabs/templates/sessions/edit_session.html
+++ b/sciencelabs/templates/sessions/edit_session.html
@@ -87,7 +87,7 @@
                        value="{{ session_info.endTime|datetimeformat('%H:%M') }}">
             </div>
         </div>
-        {{ macros.select_courses(course_list) }}
+        {{ macros.select_courses(course_list, session_course_ids) }}
         <div class="form-row">
             <div class="form-group col-md-12">
                 <label for="comments">Comments</label>

--- a/sciencelabs/term_startup/__init__.py
+++ b/sciencelabs/term_startup/__init__.py
@@ -53,13 +53,12 @@ class TermStartupView(FlaskView):
         try:
             self.schedule.set_current_term(term, year, start_date, end_date)  # Sets the new term to active
             self.user.deactivate_students()  # Soft deletes all students
-            self.user.demote_tutors()  # Demotes all lead tutors to regular tutors
-            self.user.populate_courses_cron()  # Pulls in new courses and profs from banner
-            semester = Schedule().get_active_semester()
+            semester = self.schedule.get_active_semester()
             flask_session['SEMESTER-LIST'] = \
                 [{'id': semester.id, 'term': semester.term, 'year': semester.year, 'active': semester.active}] + \
                 flask_session['SEMESTER-LIST']
             flask_session['SELECTED-SEMESTER'] = semester.id
+            flask_session.modified = True
             self.slc.set_alert('success', 'Term {0} {1} set successfully!'.format(term, year))
             return redirect(url_for('TermStartupView:step_two'))
         except Exception as error:


### PR DESCRIPTION
This PR is all about smoothing out the term startup process. The following things were accomplished:

1. On term startup I confirmed that the new semester is immediately visible and all students are soft deleted. We used to try to demote tutors too, but that function has been abandoned.

2. Courses weren't being pulled in properly but now they are and it's nice and smooth.

3. The checkboxes to view courses were bugged, but now they are only checked if the course is offered for a schedule or session.

4. There is also a bug fix in here to double check for an existing user in the system on user creation.

This has been tested extensively locally and on xp to ensure as few issues as possible for the admins.