### PR TITLE
Add in "other" count to course report

### DIFF
--- a/sciencelabs/db_repository/course_functions.py
+++ b/sciencelabs/db_repository/course_functions.py
@@ -38,6 +38,15 @@ class Course:
                 .filter(Semester_Table.id == semester_id)
                 .all())
 
+    def get_other_info(self, semester_id):
+        return db_session.query(StudentSession_Table)\
+            .filter(User_Table.id == StudentSession_Table.studentId)\
+            .filter(StudentSession_Table.otherCourseName != None)\
+            .filter(StudentSession_Table.sessionId == Session_Table.id)\
+            .filter(Session_Table.semester_id == Semester_Table.id)\
+            .filter(Semester_Table.id == semester_id)\
+            .all()
+
     def get_selected_prof_course_info(self, semester_id, prof_id):
         return (db_session.query(Course_Table, User_Table)
                 .filter(User_Table.id == prof_id)

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -693,6 +693,7 @@ class ReportView(FlaskView):
                 or ('ADMIN-VIEWER' in flask_session.keys() and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
 
             course_info = self.courses.get_selected_course_info(flask_session['SELECTED-SEMESTER'])
+            other_info = self.courses.get_other_info(flask_session['SELECTED-SEMESTER'])
             course_viewer_info = None
 
         else:  # They must be a professor

--- a/sciencelabs/templates/reports/course.html
+++ b/sciencelabs/templates/reports/course.html
@@ -104,9 +104,15 @@
                             {% endfor %}
                         </tbody>
                         <tfoot>
+                            {% if other_info %}
+                                <tr>
+                                    <th class="no-border-top" colspan="4">Other</th>
+                                    <th class="no-border-top">{{ other_info|length }}</th>
+                                </tr>
+                            {% endif %}
                             <tr>
                                 <th class="no-border-top" colspan="4">Total</th>
-                                <th class="no-border-top">{{ total_attendance[0] }}</th>
+                                <th class="no-border-top">{{ total_attendance[0] + other_info|length }}</th>
                                 <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
                             </tr>
                         </tfoot>


### PR DESCRIPTION
## Description

Updated the Course Report page so it also displays the total number of "other" attendance. This number is then added to the total number.

![Screen Shot 2019-10-30 at 12 55 11 PM](https://user-images.githubusercontent.com/26125143/67884851-87eec280-fb14-11e9-8731-f110ea755e56.png)

Fixes #177 

## Size and Type of change

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Locally displays the information

## Checklist:

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)