### PR TITLE
Change before_request so semester list is updated everytime

### DIFF
--- a/sciencelabs/__init__.py
+++ b/sciencelabs/__init__.py
@@ -124,18 +124,15 @@ def before_request():
             flask_session['USER-ROLES'] = ['STUDENT']
         if 'ADMIN-VIEWER' not in flask_session.keys():
             flask_session['ADMIN-VIEWER'] = False
-        if 'SEMESTER-LIST' not in flask_session.keys():
-            semester_list = Schedule().get_semesters()
-            flask_session['SEMESTER-LIST'] = []
+        semester_list = Schedule().get_semesters()
+        flask_session['SEMESTER-LIST'] = []
+        for semester in semester_list:
             # Adds all semesters to a dictionary
-            for semester in semester_list:
-                flask_session['SEMESTER-LIST'].append(
-                    {'id': semester.id, 'term': semester.term, 'year': semester.year, 'active': semester.active})
+            flask_session['SEMESTER-LIST'].append(
+                {'id': semester.id, 'term': semester.term, 'year': semester.year, 'active': semester.active})
+            if 'SELECTED-SEMESTER' not in flask_session.keys() and semester.active == 1:
                 # Sets the current active semester to 'SELECTED-SEMESTER'
-                if semester.active == 1:
-                    flask_session['SELECTED-SEMESTER'] = semester.id
-        if 'SELECTED-SEMESTER' not in flask_session.keys():
-            flask_session['SELECTED-SEMESTER'] = active_semester.id
+                flask_session['SELECTED-SEMESTER'] = semester.id
         if 'ALERT' not in flask_session.keys():
             flask_session['ALERT'] = []
 


### PR DESCRIPTION
## Description

Hopefully solved the semester selector issue by forcing the semester list to be updated before every request by grabbing all the semesters from the db. The performance hit is negligible (0.03 to 0.008 seconds difference).

Fixes #180 

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

I wasn't exactly sure how to test this so I haven't, but all the code seems to make logical sense

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
