### PR TITLE
Fix bug where some sessions didn't show up when viewing a course

### DIFF
--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -163,8 +163,7 @@ class Session:
             .one()
 
     def get_sessions(self, course_id):
-        return db_session.query(Session_Table, Schedule_Table)\
-            .filter(Session_Table.schedule_id == Schedule_Table.id)\
+        return db_session.query(Session_Table)\
             .filter(Session_Table.id == StudentSession_Table.sessionId)\
             .filter(StudentSession_Table.id == SessionCourses_Table.studentsession_id)\
             .filter(SessionCourses_Table.course_id == course_id)\

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -818,9 +818,8 @@ class ReportView(FlaskView):
 
         sessions = self.session_.get_sessions(course_id)
         sessions_and_attendance = {}
-        for lab_session, schedule in sessions:
+        for lab_session in sessions:
             sessions_and_attendance[lab_session] = {
-                'schedule': schedule,
                 'attendance': self.session_.get_session_attendees_with_dup(course.id, lab_session.id)
 
             }

--- a/sciencelabs/templates/reports/view_course.html
+++ b/sciencelabs/templates/reports/view_course.html
@@ -54,7 +54,7 @@
                     <tr>
                         <td>{{ lab_session.date.strftime('%m/%d/%Y') }}</td>
                         <td>
-                            {{ macros.day_abbr(info['schedule'].dayofWeek) }}
+                            {{ macros.day_abbr((lab_session.date.weekday() + 1) % 7) }}
                         </td>
                         <td>{{ lab_session.schedStartTime|datetimeformat }} - {{ lab_session.schedEndTime|datetimeformat }}</td>
                         {% set attendance_per_session = info['attendance'] %}


### PR DESCRIPTION
## Description

A session wasn't appearing in the course tab even though the session occurred. This was due to the session not being part of a schedule (I think it wasn't part of a schedule since it occurred on the last day of the semester so it wasn't assigned a schedule). This led to the session not showing up in the course tab since only sessions with a schedule will show up there. That is a bug that I have taken care of by removing the schedule check when populating the sessions for specific courses.

## Size and Type of change

- Small Change - 1 person needs to review this
- Bug fix

## How Has This Been Tested?

I tested this issue with the session that was causing the issue and it now shows up.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
