### PR TITLE
Fixed Email Student Total

### DIFF
--- a/sciencelabs/templates/email_tab/send_email_confirm.html
+++ b/sciencelabs/templates/email_tab/send_email_confirm.html
@@ -13,7 +13,7 @@
         <div class="form-row">
             <div class="form-group col-md-6">
                 <label for="choose-recipients">Recipients</label>
-                <select name="groups" id="choose-recipients" multiple="true"">
+                <select name="groups" id="choose-recipients" multiple="true">
                     {% for role in role_list %}
                         <option value="{{ role.id }}" {{ 'selected' if role.id in groups }}>{{ role.name }}</option>
                     {% endfor %}

--- a/sciencelabs/templates/sessions/email.html
+++ b/sciencelabs/templates/sessions/email.html
@@ -88,6 +88,7 @@
 {% endif %}
 
 <h3>Student Attendance (by name)</h3>
+{% set student_attendance = [0] %}
 <table style="border-collapse:collapse;min-width:300px">
     <tr>
         <th style="padding:2px 10px">Name</th>
@@ -97,7 +98,7 @@
         <th style="padding:2px 10px">Course(s)</th>
     </tr>
     {% for student, courses in students_and_courses.items() %}
-
+        {% if student_attendance.append(student_attendance.pop() + (1)) %}{% endif %}
         <tr>
             <td style="border-bottom: 1px solid #CCC;padding:2px 10px">{{ student.firstName }} {{ student.lastName }}</td>
             <td style="border-bottom: 1px solid #CCC;padding:2px 10px">
@@ -166,6 +167,7 @@
 {% endfor %}
 </table>
 
+{% set total_student_attendance = [student_attendance[0] + sess.anonStudents] %}
 <h3>Course Attendance</h3>
 <table style="border-collapse:collapse;min-width:300px">
     <tr>
@@ -194,7 +196,6 @@
             <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ attendance[0] }}</td>
         </tr>
     {% endfor %}
-    {% set attendees = [total_attendance[0] + sess.anonStudents] %}
     <tr>
         <td colspan="2" style="border-bottom: 1px solid #CCC;padding:2px 10px"><b>Course Total*</b></td>
         <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ course_attendance[0] }}</td>
@@ -215,7 +216,7 @@
     </tr>
     <tr>
         <td colspan="2" style="border-bottom: 1px solid #CCC;padding:2px 10px"><b>Student Total</b></td>
-        <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ attendees[0] }}</td>
+        <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ total_student_attendance[0] }}</td>
     </tr>
 </table>
 <br />

--- a/sciencelabs/templates/sessions/email.html
+++ b/sciencelabs/templates/sessions/email.html
@@ -173,13 +173,13 @@
         <th style="padding:2px 10px">Professor</th>
         <th style="padding:2px 10px">Attendance</th>
     </tr>
-    {% set total_attendance = [0] %}
+    {% set course_attendance = [0] %}
     {% for course, info in courses_and_info.items() %}
         {% set attendance = [0] %}
         {% for student in info['students'] %}
             {% if attendance.append(attendance.pop() + 1) %}{% endif %}
         {% endfor %}
-        {% if total_attendance.append(total_attendance.pop() + attendance[0]) %}{% endif %}
+        {% if course_attendance.append(course_attendance.pop() + attendance[0]) %}{% endif %}
         <tr>
             <td style="border-bottom: 1px solid #CCC;padding:2px 10px">
                 <a href="https://tutorlabs.bethel.edu{{ lab_base_url }}/report/course/{{ course.id }}">
@@ -197,7 +197,7 @@
     {% set attendees = [total_attendance[0] + sess.anonStudents] %}
     <tr>
         <td colspan="2" style="border-bottom: 1px solid #CCC;padding:2px 10px"><b>Course Total*</b></td>
-        <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ total_attendance[0] }}</td>
+        <td style="border-bottom: 1px solid #CCC;padding:2px 10px;text-align:right">{{ course_attendance[0] }}</td>
     </tr>
     <tr>
         <td colspan="2" style="border-bottom: 1px solid #CCC;padding:2px 10px"><b>Other Students Total</b></td>


### PR DESCRIPTION
## Description

Student totals in the end of session email were the exact same as the course total so students were being doubled counted which shouldn't be happening

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Locally I recreated the issue with a past session and then fixed the issue

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)
