### PR TITLE
Swipe sign out

### DIFF
--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -459,8 +459,7 @@ class SessionView(FlaskView):
                 student_info = self.wsapi.get_user_from_prox(card_id)
                 username = student_info['username']
             except:
-                self.slc.set_alert('danger', 'Card not recognized. Please try again or click the button below to enter '
-                                             'your Bethel username and password.')
+                self.slc.set_alert('danger', 'Card not recognized. Please try again or or sign in/out manually.')
                 return redirect(url_for('SessionView:student_attendance_passthrough', session_id=session_id, session_hash=session_hash))
             student = self.user.get_user_by_username(username)
 
@@ -552,8 +551,7 @@ class SessionView(FlaskView):
             try:
                 tutor_info = self.wsapi.get_user_from_prox(card_id)
             except:
-                self.slc.set_alert('danger', 'Card not recognized. Please try again or click the button below to enter '
-                                             'your Bethel username and password.')
+                self.slc.set_alert('danger', 'Card not recognized. Please try again or sign in/out manually.')
                 return redirect(url_for('SessionView:tutor_attendance_passthrough', session_id=session_id, session_hash=session_hash))
             tutor = self.user.get_user_by_username(tutor_info['username'])
         else:

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -489,8 +489,9 @@ class SessionView(FlaskView):
 
         # Check if student is already signed in
         if self.session.student_currently_signed_in(session_id, student.id):
-            self.slc.set_alert('danger', 'Student currently signed in')
-            return redirect(url_for('SessionView:student_attendance_passthrough', session_id=session_id, session_hash=session_hash))
+
+            return redirect(url_for('SessionView:student_sign_out', session_id=session_id, student_id=student.id,
+                                    session_hash=session_hash))
         student_courses = self.user.get_student_courses(student.id, semester.id)
         time_in = datetime.now().strftime("%I:%M%p")
 

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -571,7 +571,7 @@ class SessionView(FlaskView):
             return redirect(url_for('SessionView:tutor_attendance_passthrough', session_id=session_id, session_hash=session_hash))
         if self.session.tutor_currently_signed_in(session_id, tutor.id):
             self.slc.set_alert('danger', 'Tutor currently signed in')
-            return redirect(url_for('SessionView:tutor_attendance_passthrough', session_id=session_id, session_hash=session_hash))
+            return redirect(url_for('SessionView:tutor_sign_out', session_id=session_id, tutor_id=tutor.id, session_hash=session_hash))
         self.session.tutor_sign_in(session_id, tutor.id)
 
         return redirect(url_for('SessionView:tutor_attendance_passthrough', session_id=session_id, session_hash=session_hash))

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -459,7 +459,7 @@ class SessionView(FlaskView):
                 student_info = self.wsapi.get_user_from_prox(card_id)
                 username = student_info['username']
             except:
-                self.slc.set_alert('danger', 'Card not recognized. Please try again or or sign in/out manually.')
+                self.slc.set_alert('danger', 'Card not recognized. Please try again or ask a tutor to sign you in/out.')
                 return redirect(url_for('SessionView:student_attendance_passthrough', session_id=session_id, session_hash=session_hash))
             student = self.user.get_user_by_username(username)
 

--- a/sciencelabs/templates/sessions/student_attendance.html
+++ b/sciencelabs/templates/sessions/student_attendance.html
@@ -63,7 +63,7 @@
                         {{ student.timeOut|datetimeformat}}
                     {% else %}
                         <a href="{{ url_for('SessionView:student_sign_out', session_id=session_info.id, student_id=student.id, session_hash=session_info.hash) }}"
-                                   class="delete btn btn-primary">Scan ID to Sign Out</a>
+                                   class="delete btn btn-primary">Scan ID or Click Here to Sign Out</a>
                     {% endif %}
                 </td>
             </tr>

--- a/sciencelabs/templates/sessions/student_attendance.html
+++ b/sciencelabs/templates/sessions/student_attendance.html
@@ -63,7 +63,7 @@
                         {{ student.timeOut|datetimeformat}}
                     {% else %}
                         <a href="{{ url_for('SessionView:student_sign_out', session_id=session_info.id, student_id=student.id, session_hash=session_info.hash) }}"
-                                   class="delete btn btn-primary">Sign Out</a>
+                                   class="delete btn btn-primary">Scan ID to Sign Out</a>
                     {% endif %}
                 </td>
             </tr>

--- a/sciencelabs/templates/sessions/tutor_attendance.html
+++ b/sciencelabs/templates/sessions/tutor_attendance.html
@@ -55,7 +55,7 @@
                             {% else %}
                                 <td>
                                     <a href="{{ url_for('SessionView:tutor_sign_out', session_id=session_info.id, tutor_id=tutor.id, session_hash=session_info.hash) }}"
-                                       class="delete btn btn-primary">Sign Out</a>
+                                       class="delete btn btn-primary">Scan ID to Sign Out</a>
                                 </td>
                             {% endif %}
                         </tr>

--- a/sciencelabs/templates/sessions/tutor_attendance.html
+++ b/sciencelabs/templates/sessions/tutor_attendance.html
@@ -55,7 +55,7 @@
                             {% else %}
                                 <td>
                                     <a href="{{ url_for('SessionView:tutor_sign_out', session_id=session_info.id, tutor_id=tutor.id, session_hash=session_info.hash) }}"
-                                       class="delete btn btn-primary">Scan ID to Sign Out</a>
+                                       class="delete btn btn-primary">Scan ID or Click Here to Sign Out</a>
                                 </td>
                             {% endif %}
                         </tr>


### PR DESCRIPTION
## Description

Add in the ability to sign out of a session with a card scan (for both tutors and students). I did this by piggy-backing off of built in functionality and error checking which throws an error when a student tries to sign in while already signed in. Now instead of throwing an error it just signs the student out.

Fixes part 1 of https://jira.bethel.edu/browse/ITS-212696

## Size and Type of change

- Small Change - 1 person needs to review this

- New feature

## How Has This Been Tested?

I created a test session on xp and logged in both as a student and tutor using my card # and then logged out using my card #.

## Checklist:

Only check what applies and what you have done.

- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)