### PR TITLE
add in person/online to student info table for close session email

### DIFF
--- a/sciencelabs/templates/sessions/email.html
+++ b/sciencelabs/templates/sessions/email.html
@@ -96,6 +96,7 @@
         <th style="padding:2px 10px">Time Out</th>
         <th style="padding:2px 10px">Time in Lab</th>
         <th style="padding:2px 10px">Course(s)</th>
+        <th style="padding:2px 10px">Attendance</th>
     </tr>
     {% for student, courses in students_and_courses.items() %}
         {% if student_attendance.append(student_attendance.pop() + (1)) %}{% endif %}
@@ -127,6 +128,13 @@
                 {% endfor %}
                 {% if student.otherCourse and student.otherCourseName %}
                     {{ student.otherCourseName }}
+                {% endif %}
+            </td>
+            <td>
+                {% if student.online %}
+                    Online
+                {% else %}
+                    In Person
                 {% endif %}
             </td>
         </tr>


### PR DESCRIPTION
## Description

On close session email the attendance of each student (online/in person) was added to the student attendance table 

Fixes # (issue)

#202 

Delete any of these you don't use.

- Small Change - 1 person needs to review this

## How Has This Been Tested?

Tested locally

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)