### PR TITLE
allow virtual reservations

### DIFF
--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -26,11 +26,10 @@ class Session:
                 if session.room_group_id:
                     room_group_id = session.room_group_id
 
-            if room.lower() != 'virtual':
-                if room_group_id:
-                    self.update_room_grouping(room_group_id, sessions)
-                else:
-                    self.create_room_grouping(sessions)
+            if room_group_id:
+                self.update_room_grouping(room_group_id, sessions)
+            else:
+                self.create_room_grouping(sessions)
 
     def get_sessions_by_date_time_and_room(self, date, start_time, end_time, room):
         return db_session.query(Session_Table) \
@@ -792,8 +791,8 @@ class Session:
                            actual_end, room, comments, anon_students, name, leads, tutors, courses):
         new_session = self.create_session(semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url,
                                           actual_start, actual_end, room, comments, anon_students, name)
-        if room.lower() != 'virtual':
-            self.create_seats(new_session.id, capacity)
+
+        self.create_seats(new_session.id, capacity)
         self.create_lead_sessions(scheduled_start, scheduled_end, leads, new_session.id)
         self.create_tutor_sessions(scheduled_start, scheduled_end, tutors, new_session.id)
         self.create_session_courses(new_session.id, courses)

--- a/sciencelabs/schedule/__init__.py
+++ b/sciencelabs/schedule/__init__.py
@@ -140,37 +140,38 @@ class ScheduleView(FlaskView):
         courses = form.getlist('courses')
         sessions = self.schedule.get_sessions_by_schedule(schedule_id)
         for session in sessions:
-            reserved_seats = self.session.get_num_reserved_seats(session.id)
-            if session.capacity > capacity:
-                # If the session capacity is greater than the new capacity and more seats are reserved than the new
-                # capacity error out
-                if reserved_seats > capacity:
-                    self.slc.set_alert('danger',
-                                       'Failed to edit session: More students have reserved this session than '
-                                       'the new session capacity allows.')
-                    return redirect(url_for('ScheduleView:edit_schedule', schedule_id=schedule_id))
-                # Else this means there are less reservations than the new capacity so delete unused seats and shift
-                # students
-                elif reserved_seats <= capacity:
-                    reservations = self.session.get_session_reservations(session.id)
-                    capacity_issue = False
-                    for reservation in reservations:
-                        if reservation.seat_number > capacity:
-                            capacity_issue = True
-                            break
-                    if not capacity_issue:
-                        self.session.delete_seats(session.id, capacity, session.capacity)
-                    else:
+            if session.date >= datetime.now().date():
+                reserved_seats = self.session.get_num_reserved_seats(session.id)
+                if session.capacity > capacity:
+                    # If the session capacity is greater than the new capacity and more seats are reserved than the new
+                    # capacity error out
+                    if reserved_seats > capacity:
                         self.slc.set_alert('danger',
-                                           'There are is an issue where someone has a seat number greater than '
-                                           'the session capacity for the session.')
-                        return redirect(url_for('SessionView:view_session_reservations', session_id=session.id))
-            elif session.capacity < capacity > self.session.get_total_seats(session.id):
-                # If the new capacity is greater than the current session capacity and there are less seats than the new
-                # capacity, create new seats
-                self.session.create_seats(session.id, capacity, session.capacity + 1, False)
-            elif len(self.session.get_all_session_reservations(session.id)) == 0:
-                self.session.create_seats(session_id=session.id, capacity=capacity, commit=False)
+                                           'Failed to edit session: More students have reserved this session than '
+                                           'the new session capacity allows.')
+                        return redirect(url_for('ScheduleView:edit_schedule', schedule_id=schedule_id))
+                    # Else this means there are less reservations than the new capacity so delete unused seats and shift
+                    # students
+                    elif reserved_seats <= capacity:
+                        reservations = self.session.get_session_reservations(session.id)
+                        capacity_issue = False
+                        for reservation in reservations:
+                            if reservation.seat_number > capacity:
+                                capacity_issue = True
+                                break
+                        if not capacity_issue:
+                            self.session.delete_seats(session.id, capacity, session.capacity)
+                        else:
+                            self.slc.set_alert('danger',
+                                               'There are is an issue where someone has a seat number greater than '
+                                               'the session capacity for the session.')
+                            return redirect(url_for('SessionView:view_session_reservations', session_id=session.id))
+                elif session.capacity < capacity > self.session.get_total_seats(session.id):
+                    # If the new capacity is greater than the current session capacity and there are less seats than the new
+                    # capacity, create new seats
+                    self.session.create_seats(session.id, capacity, session.capacity + 1, False)
+                elif len(self.session.get_all_session_reservations(session.id)) == 0:
+                    self.session.create_seats(session_id=session.id, capacity=capacity, commit=False)
         try:
             # This returns True if it executes successfully
             sessions = self.schedule.edit_schedule(term_start_date, term_end_date, term_id, schedule_id, name, room,

--- a/sciencelabs/student/__init__.py
+++ b/sciencelabs/student/__init__.py
@@ -34,8 +34,7 @@ class StudentView(FlaskView):
 
         sessions = []
         for session in result_sessions:
-            if session.room.lower() != 'virtual':
-                sessions.append(session)
+            sessions.append(session)
 
         open_sessions, valid_session_courses = self.check_session_courses(self.session.get_open_sessions())
         signed_in_sessions = []
@@ -49,6 +48,9 @@ class StudentView(FlaskView):
                 signed_in_sessions.append(session)
                 signed_in_courses[session.id] = self.session.get_student_session_courses(session.id, student.id)
 
+        for s in sessions:
+            if s.room.lower() == 'virtual' and self.session.is_reserved(s.id, student.id):
+                sessions.remove(s)
         return render_template('student/reservations.html', **locals(), is_reserved=self.session.is_reserved,
                                get_seats_available=self.session.get_num_seats_available)
 
@@ -66,11 +68,16 @@ class StudentView(FlaskView):
         signed_in_sessions = []
         signed_in_courses = {}
         for session in open_sessions:
+            if session.room.lower() == 'virtual' and not self.session.is_reserved(session.id, student.id):
+                open_sessions.remove(session)
             signed_in = self.session.student_currently_signed_in(session.id, student.id)
             if signed_in:
                 signed_in_sessions.append(session)
                 signed_in_courses[session.id] = self.session.get_signed_in_courses(session.id, student.id)
 
+        for s in sessions:
+            if s.room.lower() == 'virtual' and not self.session.is_reserved(s.id, student.id):
+                sessions.remove(s)
         return render_template('student/virtual_sign_on.html', **locals())
 
     @route('/load-modal', methods=['POST'])

--- a/sciencelabs/student/__init__.py
+++ b/sciencelabs/student/__init__.py
@@ -48,9 +48,6 @@ class StudentView(FlaskView):
                 signed_in_sessions.append(session)
                 signed_in_courses[session.id] = self.session.get_student_session_courses(session.id, student.id)
 
-        for s in sessions:
-            if s.room.lower() == 'virtual' and self.session.is_reserved(s.id, student.id):
-                sessions.remove(s)
         return render_template('student/reservations.html', **locals(), is_reserved=self.session.is_reserved,
                                get_seats_available=self.session.get_num_seats_available)
 


### PR DESCRIPTION
## Description

Sessions with a room name 'virtual' have the ability to specify capacity and to reserve seats in the session. Once a virtual session is reserved it is removed from the reservations tab. Virtual sessions only show up on the virtual sign on page if the student has the session reserved and the session has been started. 

Fixes #206 

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Tested locally

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)