### PR TITLE
Fix email newline bug

### DIFF
--- a/sciencelabs/templates/email_tab/base.html
+++ b/sciencelabs/templates/email_tab/base.html
@@ -111,7 +111,7 @@
                 url: "{{ url_for('EmailView:send_email_confirm') }}",
                 data: JSON.stringify({
                     'subject': $('#subject').val(),
-                    'message': $('#message').val(),
+                    'message': JSON.stringify($('#message').val()),
                     'selected_recipients': $('#choose-recipients').val(),
                     'selected_groups': $('#choose-bcc-groups').val(),
                     'selected_bcc': $('#choose-bcc').val()

--- a/sciencelabs/templates/email_tab/email_all_reservations.html
+++ b/sciencelabs/templates/email_tab/email_all_reservations.html
@@ -87,7 +87,7 @@
                 url: "{{ url_for('SessionView:email_all_reservations_confirm') }}",
                 data: JSON.stringify({
                     'subject': $('#subject').val(),
-                    'message': $('#message').val(),
+                    'message': JSON.stringify($('#message').val()),
                     'selected_reservations': $('#choose-reservations').val(),
                     'selected_tutors': $('#choose-tutors').val(),
                     'selected_users': $('#choose-users').val()

--- a/sciencelabs/templates/email_tab/email_confirm_modal.html
+++ b/sciencelabs/templates/email_tab/email_confirm_modal.html
@@ -40,7 +40,7 @@
                 url: url,
                 data: JSON.stringify({
                     'subject': '{{ subject }}',
-                    'message': '{{ message }}',
+                    'message': {{ message|safe }},
                     'recipients': {{ recipients|safe }},
                     'bcc': {{ bcc_emails|safe }}
                 }),


### PR DESCRIPTION
## Description

Fixes bug that made email messages with new line in them unable to send. Fixes both email all reservations button and the email tab.

## Size and Type of change

- Small Change - 1 person needs to review this

- Bug fix

## How Has This Been Tested?

Please briefly describe the tests that you ran to verify your changes.

Tested locally

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)