### PR TITLE
Non online functionality

### DIFF
--- a/sciencelabs/db_repository/db_tables.py
+++ b/sciencelabs/db_repository/db_tables.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, DateTime
+from sqlalchemy import Column, Integer, String, DateTime, Boolean
 
 from sciencelabs.db_repository import base
 
@@ -127,6 +127,7 @@ class Session_Table(base):
     zoom_url = Column(String)
     capacity = Column(Integer)
     room_group_id = Column(Integer)
+    in_person = Column(Boolean)
 
 
 class SessionReservations_Table(base):

--- a/sciencelabs/db_repository/schedule_functions.py
+++ b/sciencelabs/db_repository/schedule_functions.py
@@ -193,13 +193,13 @@ class Schedule:
         return course_list
 
     def create_schedule(self, term, term_start_date, term_end_date, term_id, name, room, start_time, end_time,
-                        day_of_week, capacity, leads, tutors, courses):
+                        day_of_week, capacity, leads, tutors, courses, in_person):
         # Creates the schedule and returns it
         new_schedule = self.create_new_schedule(name, room, start_time, end_time, day_of_week, term)
         # Creates the recurring sessions for the schedule and returns them in an array
         scheduled_sessions = self.create_scheduled_sessions(term_start_date, term_end_date, day_of_week, term_id,
                                                             new_schedule.id, start_time, end_time, capacity, None, room,
-                                                            name)
+                                                            name, in_person)
         # Creates leads tutor schedules
         self.create_new_lead_schedules(new_schedule.id, start_time, end_time, leads)
         # Creates leads recurring tutor sessions
@@ -243,14 +243,14 @@ class Schedule:
         db_session.commit()
 
     def create_scheduled_sessions(self, term_start_date, term_end_date, day_of_week, term_id, schedule_id, start_time,
-                                  end_time, capacity, zoom_url, room, name):
+                                  end_time, capacity, zoom_url, room, name, in_person):
         sessions = []
         session_date = self.get_first_session_date(day_of_week, term_start_date)
         while session_date <= term_end_date:  # Loop through until our session date is after the end date of the term
             schedule_session = Session_Table(semester_id=term_id, schedule_id=schedule_id,
                                              date=session_date, schedStartTime=start_time,
                                              schedEndTime=end_time, room=room, open=0, hash=self.base.get_hash(),
-                                             anonStudents=0, name=name, capacity=capacity, zoom_url=zoom_url)
+                                             anonStudents=0, name=name, capacity=capacity, zoom_url=zoom_url, in_person=in_person)
             db_session.add(schedule_session)
             db_session.commit()
             sessions.append(schedule_session)
@@ -306,7 +306,7 @@ class Schedule:
     ######################## EDIT SCHEDULE METHODS #########################
 
     def edit_schedule(self, term_start_date, term_end_date, term_id, schedule_id, name, room, start_time,
-                      end_time, day_of_week, capacity, leads, tutors, courses):
+                      end_time, day_of_week, capacity, leads, tutors, courses, in_person):
         # Gets an array of sessions based on the schedule id
         scheduled_sessions = self.get_sessions_by_schedule(schedule_id)
 
@@ -323,7 +323,7 @@ class Schedule:
         self.edit_schedule_info(schedule_id, name, room, start_time, end_time, day_of_week)
         # Creates the new recurring sessions for the schedule
         new_sessions = self.create_scheduled_sessions(term_start_date, term_end_date, day_of_week, term_id,
-                                                      schedule_id, start_time, end_time, capacity, zoom_url, room, name)
+                                                      schedule_id, start_time, end_time, capacity, zoom_url, room, name, in_person)
         # Edits the lead's schedule
         self.create_new_lead_schedules(schedule_id, start_time, end_time, leads)
         # Creates the new recurring sessions for the lead

--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -592,7 +592,7 @@ class Session:
             end_time = session.schedEndTime
             reservations_end_time = datetime.combine(session.date, datetime.strptime(str(end_time), '%H:%M:%S').time())
             reservations_start_time = datetime.combine(session.date, datetime.strptime(str(start_time), '%H:%M:%S').time())
-            if (reservations_start_time - timedelta(days=3)) <= datetime.now() <= reservations_end_time:
+            if (reservations_start_time - timedelta(days=3)) <= datetime.now() <= reservations_end_time and session.in_person is False:
                 valid_sessions.append(session)
 
         return valid_sessions
@@ -609,7 +609,7 @@ class Session:
             time = session.schedStartTime
             reservations_end_time = datetime.combine(session.date, datetime.strptime(str(time), '%H:%M:%S').time())
             reservations_start_time = datetime.combine(session.date, datetime.strptime(str(time), '%H:%M:%S').time())
-            if (reservations_start_time - timedelta(days=3)) <= datetime.now() <= reservations_end_time:
+            if (reservations_start_time - timedelta(days=3)) <= datetime.now() <= reservations_end_time and session.in_person is False:
                 valid_sessions.append(session)
 
         return valid_sessions
@@ -822,9 +822,10 @@ class Session:
     ######################### CREATE SESSION METHODS #########################
 
     def create_new_session(self, semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url, actual_start,
-                           actual_end, room, comments, anon_students, name, leads, tutors, courses):
+                           actual_end, room, comments, anon_students, name, leads, tutors, courses, in_person):
         new_session = self.create_session(semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url,
-                                          actual_start, actual_end, room, comments, anon_students, name)
+                                          actual_start, actual_end, room, comments, anon_students, name, in_person)
+
         if room.lower() != 'virtual':
             self.create_seats(new_session.id, capacity)
         self.create_lead_sessions(scheduled_start, scheduled_end, leads, new_session.id)
@@ -834,11 +835,11 @@ class Session:
         return new_session
 
     def create_session(self, semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url, actual_start,
-                       actual_end, room, comments, anon_students, name):
+                       actual_end, room, comments, anon_students, name, in_person):
         new_session = Session_Table(semester_id=semester_id, date=date, schedStartTime=scheduled_start,
                                     schedEndTime=scheduled_end, capacity=capacity, zoom_url=zoom_url,
                                     startTime=actual_start, endTime=actual_end, room=room, open=0, comments=comments,
-                                    anonStudents=anon_students, name=name, hash=self.base.get_hash())
+                                    anonStudents=anon_students, name=name, in_person=in_person, hash=self.base.get_hash())
         db_session.add(new_session)
         db_session.commit()
         return new_session

--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -893,15 +893,15 @@ class Session:
         db_session.commit()
 
     def edit_session(self, session_id, semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url,
-                     actual_start, actual_end, room, comments, anon_students, name, leads, tutors, courses):
+                     actual_start, actual_end, room, comments, anon_students, name, leads, tutors, courses, in_person):
         self.edit_session_info(session_id, semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url, actual_start,
-                               actual_end, room, comments, anon_students, name)
+                               actual_end, room, comments, anon_students, name, in_person)
         self.edit_session_leads(scheduled_start, scheduled_end, leads, session_id)
         self.edit_session_tutors(scheduled_start, scheduled_end, tutors, session_id)
         self.edit_session_courses(session_id, courses)
 
     def edit_session_info(self, session_id, semester_id, date, scheduled_start, scheduled_end, capacity, zoom_url,
-                          actual_start, actual_end, room, comments, anon_students, name):
+                          actual_start, actual_end, room, comments, anon_students, name, in_person):
         session_to_edit = db_session.query(Session_Table).filter(Session_Table.id == session_id).one()
         session_to_edit.semester_id = semester_id
         session_to_edit.date = date
@@ -915,6 +915,7 @@ class Session:
         session_to_edit.comments = comments
         session_to_edit.anonStudents = anon_students
         session_to_edit.name = name
+        session_to_edit.in_person = in_person
         db_session.commit()
 
     def edit_session_leads(self, scheduled_start, scheduled_end, leads, session_id):

--- a/sciencelabs/schedule/__init__.py
+++ b/sciencelabs/schedule/__init__.py
@@ -139,6 +139,13 @@ class ScheduleView(FlaskView):
         leads = form.getlist('leads')
         tutors = form.getlist('tutors')
         courses = form.getlist('courses')
+        in_person = form.get('in-person')
+        if in_person is None:
+            in_person = 0
+        else:
+            in_person = 1
+            capacity = 0
+
         sessions = self.schedule.get_sessions_by_schedule(schedule_id)
         for session in sessions:
             if room.lower() != 'virtual' and session.date >= datetime.now().date():
@@ -178,7 +185,7 @@ class ScheduleView(FlaskView):
         try:
             # This returns True if it executes successfully
             sessions = self.schedule.edit_schedule(term_start_date, term_end_date, term_id, schedule_id, name, room,
-                                                   start_time, end_time, day_of_week, capacity, leads, tutors, courses)
+                                                   start_time, end_time, day_of_week, capacity, leads, tutors, courses, in_person)
             if room.lower() != 'virtual':
                 self.session.check_all_room_groupings(sessions)
             self.session.delete_extra_room_groupings()
@@ -223,8 +230,15 @@ class ScheduleView(FlaskView):
             leads = form.getlist('leads')
             tutors = form.getlist('tutors')
             courses = form.getlist('courses')
+            in_person = form.get('in-person')
+            if in_person is None:
+                in_person = 0
+            else:
+                in_person = 1
+                capacity = 0
+            print("sessions in person: ", in_person)
             sessions = self.schedule.create_schedule(term, term_start_date, term_end_date, term_id, name, room,
-                                                     start_time, end_time, day_of_week, capacity, leads, tutors, courses)
+                                                     start_time, end_time, day_of_week, capacity, leads, tutors, courses, in_person)
 
             if room.lower() != 'virtual':
                 self.session.check_all_room_groupings(sessions)

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -264,6 +264,12 @@ class SessionView(FlaskView):
         courses = form.getlist('courses')
         comments = form.get('comments')
         anon_students = form.get('anon-students')
+        in_person = form.get('in-person')
+        if in_person is None:
+            in_person = 0
+        else:
+            in_person = 1
+            capacity = 0
 
         session = self.session.get_session(session_id)
 
@@ -303,7 +309,7 @@ class SessionView(FlaskView):
         try:
             self.session.edit_session(session_id, semester_id, db_date, scheduled_start, scheduled_end, capacity,
                                       zoom_url, actual_start, actual_end, room, comments, anon_students, name, leads,
-                                      tutors, courses)
+                                      tutors, courses, in_person)
             if room.lower() != 'virtual':
                 self.session.check_room_grouping(db_date, scheduled_start, scheduled_end, room)
             self.session.delete_extra_room_groupings()
@@ -501,6 +507,7 @@ class SessionView(FlaskView):
             in_person = 0
         else:
             in_person = 1
+            capacity = 0
 
         # Check to see if the session being created is a past session with no actual times. This shouldn't be allowed.
         active_semester = self.schedule.get_active_semester()
@@ -882,7 +889,7 @@ class SessionView(FlaskView):
 
     @route('/no-cas/confirm-close', methods=['POST'])
     def confirm_close(self):
-        self.slc.check_roles_and_route(['Administrator', 'Lead Tutor'])
+        #self.slc.check_roles_and_route(['Administrator', 'Lead Tutor'])
 
         form = request.form
         session_id = form.get('session-id')

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -496,6 +496,11 @@ class SessionView(FlaskView):
         courses = form.getlist('courses')
         comments = form.get('comments')
         anon_students = form.get('anon-students')
+        in_person = form.get('in-person')
+        if in_person is None:
+            in_person = 0
+        else:
+            in_person = 1
 
         # Check to see if the session being created is a past session with no actual times. This shouldn't be allowed.
         active_semester = self.schedule.get_active_semester()
@@ -508,7 +513,7 @@ class SessionView(FlaskView):
         try:
             new_session = self.session.create_new_session(semester_id, db_date, scheduled_start, scheduled_end, capacity, zoom_url,
                                                       actual_start, actual_end, room, comments, anon_students, name,
-                                                      leads, tutors, courses)
+                                                      leads, tutors, courses, in_person)
             if room.lower() != 'virtual':
                 self.session.check_room_grouping(new_session.date, new_session.schedStartTime, new_session.schedEndTime, new_session.room)
 

--- a/sciencelabs/static/assets/css/sciencelabs.css
+++ b/sciencelabs/static/assets/css/sciencelabs.css
@@ -567,6 +567,10 @@ select:invalid {
     float: left;
 }
 
+.zoom-2 {
+    zoom: 2;
+}
+
 #darkblue {
     background-color: #0F2C52;
 }

--- a/sciencelabs/student/__init__.py
+++ b/sciencelabs/student/__init__.py
@@ -67,6 +67,8 @@ class StudentView(FlaskView):
         signed_in_sessions = []
         signed_in_courses = {}
         for session in open_sessions:
+            if session.in_person is True:
+                open_sessions.remove(session)
             signed_in = self.session.student_currently_signed_in(session.id, student.id)
             if signed_in:
                 signed_in_sessions.append(session)

--- a/sciencelabs/templates/schedule/create_new_schedule.html
+++ b/sciencelabs/templates/schedule/create_new_schedule.html
@@ -18,9 +18,13 @@
                         <label for="schedule-name">Schedule Name</label>
                         <input type="text" class="form-control chosen-container chosen-format" id="schedule-name" name="name" required autocomplete="off">
                     </div>
-                    <div class="form-group col-md-6">
+                    <div class="form-group col-md-4">
                         <label for="room">Room</label>
                         <input type="text" class="form-control chosen-container chosen-format" id="room" name="room" required autocomplete="off">
+                    </div>
+                    <div class="form-group col-md-2">
+                        <label>In Person</label>
+                        <input class="zoom-2" type="checkbox" name="in-person" onchange="toggle_online_vars(this)">
                     </div>
                 </div>
                 <div class="form-row">
@@ -46,7 +50,7 @@
                     </div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group col-md-12">
+                    <div id="capacity-div" class="form-group col-md-12">
                         <label for="capacity">Session Capacity</label>
                         <input type="number" min="0" class="form-control chosen-container chosen-format" id="capacity" name="capacity" value="0" required>
                     </div>
@@ -126,5 +130,15 @@
             placeholder: "Choose tutors...",
             closeOnSelect: false
         });
+
+        function toggle_online_vars(checkbox){
+            if(checkbox.checked){
+                $('#capacity-div').css("display", "none");
+                $('#capacity').removeAttr("required");
+            } else {
+                $('#capacity-div').css("display", "block");
+                $('#capacity').attr("required", "true");
+            }
+        }
     </script>
 {% endblock %}

--- a/sciencelabs/templates/schedule/edit_schedule.html
+++ b/sciencelabs/templates/schedule/edit_schedule.html
@@ -20,10 +20,14 @@
                         <input type="text" class="form-control chosen-container chosen-format" id="schedule-name" value="{{ schedule.name }}"
                                name="name" required autocomplete="off">
                     </div>
-                    <div class="form-group col-md-6">
+                    <div class="form-group col-md-4">
                         <label for="room">Room</label>
                         <input type="text" class="form-control chosen-container chosen-format" id="room" value="{{ schedule.room }}"
                                name="room" required autocomplete="off">
+                    </div>
+                    <div class="form-group col-md-2">
+                        <label>In Person</label>
+                        <input class="zoom-2" type="checkbox" name="in-person" onchange="toggle_online_vars(this)" {{ 'checked' if get_session(schedule_id).in_person }}>
                     </div>
                 </div>
                 <div class="form-row">
@@ -51,7 +55,7 @@
                     </div>
                 </div>
                 <div class="form-row">
-                    <div class="form-group col-md-12">
+                    <div id="capacity-div" class="form-group col-md-12" style="display: {{ 'none;' if get_session(schedule_id).in_person }}">
                         <label for="capacity">Session Capacity</label>
                         <input type="number" min="0" class="form-control chosen-container chosen-format" id="capacity" name="capacity" value="{{ get_session(schedule.id).capacity }}" required>
                     </div>
@@ -115,5 +119,15 @@
             placeholder: "Choose tutors...",
             closeOnSelect: false
         });
+
+        function toggle_online_vars(checkbox){
+            if(checkbox.checked){
+                $('#capacity-div').css("display", "none");
+                $('#capacity').removeAttr("required");
+            } else {
+                $('#capacity-div').css("display", "block");
+                $('#capacity').attr("required", "true");
+            }
+        }
     </script>
 {% endblock %}

--- a/sciencelabs/templates/sessions/create_session.html
+++ b/sciencelabs/templates/sessions/create_session.html
@@ -13,7 +13,7 @@
         <div class="col-md-8">
             <form class="create-session-form" action="{{ url_for('SessionView:create_session_submit') }}" method="post">
                 <div class="form-row">
-                    <div class="form-group col-md-6">
+                    <div class="form-group col-md-4">
                         <label for="session-name">Name of Session</label>
                         <input type="text" class="form-control chosen-container chosen-format" id="session-name" name="name" required autocomplete="off">
                     </div>
@@ -33,6 +33,10 @@
                             {% endfor %}
                         </select>
                     </div>
+                    <div class="form-group col-md-2">
+                        <label>In Person</label>
+                        <input class="zoom-2" type="checkbox" name="in-person" onchange="toggle_online_vars(this)">
+                    </div>
                 </div>
                 <div class="form-row">
                     <div class="form-group col-md-4">
@@ -48,8 +52,8 @@
                         <input type="time" class="form-control chosen-container chosen-format" id="scheduled-end" name="scheduled-end" required>
                     </div>
                 </div>
-                <div class="form-row">
-                    <div class="form-group col-md-6">
+                <div class="form-row" id="online-vars">
+                    <div id="capacity-div" class="form-group col-md-6">
                         <label for="capacity">Session Capacity</label>
                         <input type="number" min="0" class="form-control chosen-container chosen-format" id="capacity" name="capacity" value="0" required>
                     </div>
@@ -149,5 +153,15 @@
             placeholder: "Choose tutors...",
             closeOnSelect: false
         });
+
+        function toggle_online_vars(checkbox){
+            if(checkbox.checked){
+                $('#capacity-div').css("display", "none");
+                $('#capacity').removeAttr("required");
+            } else {
+                $('#capacity-div').css("display", "block");
+                $('#capacity').attr("required", "true");
+            }
+        }
     </script>
 {% endblock %}

--- a/sciencelabs/templates/sessions/edit_session.html
+++ b/sciencelabs/templates/sessions/edit_session.html
@@ -12,7 +12,7 @@
     <form class="edit-session-form" action="{{ url_for('SessionView:save_session_edits') }}" method="post">
         <input type="hidden" name="session-id" value="{{ session_id }}">
         <div class="form-row">
-            <div class="form-group col-md-6">
+            <div class="form-group col-md-4">
               <label for="session-name">Name of Session</label>
                 <input type="text" class="form-control chosen-container chosen-format" id="session-name" name="name"
                        value="{{ session_info.name }}" required autocomplete="off">
@@ -35,6 +35,10 @@
                     {% endfor %}
                 </select>
             </div>
+            <div class="form-group col-md-2">
+                <label>In Person</label>
+                <input class="zoom-2" type="checkbox" name="in-person" onchange="toggle_online_vars(this)" {{ 'checked' if session_info.in_person }}>
+            </div>
         </div>
         <div class="form-row">
             <div class="form-group col-md-4">
@@ -54,7 +58,7 @@
             </div>
         </div>
         <div class="form-row">
-            <div class="form-group col-md-6">
+            <div id="capacity-div" class="form-group col-md-6" style="display: {{ 'none;' if session_info.in_person }}">
                 <label for="capacity">Session Capacity</label>
                 <input type="number" min="0" class="form-control chosen-container chosen-format" id="capacity" name="capacity" value="{{ session_info.capacity }}" required>
             </div>
@@ -418,5 +422,15 @@
             placeholder: "Choose tutors...",
             closeOnSelect: false
         });
+
+        function toggle_online_vars(checkbox){
+            if(checkbox.checked){
+                $('#capacity-div').css("display", "none");
+                $('#capacity').removeAttr("required");
+            } else {
+                $('#capacity-div').css("display", "block");
+                $('#capacity').attr("required", "true");
+            }
+        }
     </script>
 {% endblock %}


### PR DESCRIPTION
## Description

Added a checkbox to specify whether sessions or schedules will be in person or not. In person sessions will not show up on the reservations tab or the virtual sign on tab. Added ability to edit the in person field from the edit session and edit schedule tabs. Added a new column to the session table on my local version of mathlab_prod.sql, using the command: ALTER TABLE session ADD COLUMN in_person TinyInt(1) DEFAULT 0;

Fixes #205 

## Size and Type of change

- Small Change - 1 person needs to review this
- New feature

## How Has This Been Tested?

- Tested locally

## Checklist:

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)