### PR TITLE
Attendance total differences

### DIFF
--- a/sciencelabs/db_repository/course_functions.py
+++ b/sciencelabs/db_repository/course_functions.py
@@ -38,6 +38,7 @@ class Course:
                 .filter(Semester_Table.id == semester_id)
                 .all())
 
+    # Replaced with get_student_attended_sessions() and get_student_attended_session_course_names 6/4/2021
     def get_other_info(self, semester_id):
         return db_session.query(StudentSession_Table)\
             .filter(User_Table.id == StudentSession_Table.studentId)\

--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -315,12 +315,13 @@ class Session:
             .filter(StudentSession_Table.id == student_session_id)\
             .one()
 
-    def get_sessions(self, course_id):
+    def get_sessions(self, course_id, semester):
         return db_session.query(Session_Table)\
             .filter(Session_Table.id == StudentSession_Table.sessionId)\
             .filter(StudentSession_Table.id == SessionCourses_Table.studentsession_id)\
             .filter(SessionCourses_Table.course_id == course_id)\
             .filter(Course_Table.id == course_id)\
+            .filter(Session_Table.semester_id == semester)\
             .all()
 
     def get_course_session(self, course_id, session_id):

--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -339,14 +339,14 @@ class Session:
             .filter(StudentSession_Table.studentId == User_Table.id)\
             .distinct()
 
-    def get_session_attendees_with_dup(self, course_id, session_id):
-        return db_session.query(StudentSession_Table, func.count(distinct(StudentSession_Table.id)))\
+    def get_session_attendees_for_course(self, course_id, session_id):
+        return db_session.query(StudentSession_Table.studentId) \
             .filter(StudentSession_Table.sessionId == session_id)\
             .filter(Session_Table.id == StudentSession_Table.sessionId)\
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id)\
             .filter(SessionCourses_Table.course_id == course_id)\
             .group_by(StudentSession_Table.id)\
-            .all()
+            .distinct()
 
     def get_student_sessions_for_course(self, course_id, session_id):
         return db_session.query(StudentSession_Table)\

--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -345,6 +345,7 @@ class Session:
             .filter(Session_Table.id == StudentSession_Table.sessionId)\
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id)\
             .filter(SessionCourses_Table.course_id == course_id)\
+            .filter(Session_Table.deletedAt == None)\
             .group_by(StudentSession_Table.id)\
             .distinct()
 
@@ -562,6 +563,7 @@ class Session:
         return db_session.query(User_Table, func.count(distinct(User_Table.id)))\
             .filter(User_Table.id == StudentSession_Table.studentId)\
             .filter(StudentSession_Table.sessionId == session_id)\
+            .filter(Session_Table.deletedAt == None)\
             .group_by(User_Table.id)\
             .all()
 

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -105,6 +105,7 @@ class User:
             .filter(Session_Table.semester_id == semester) \
             .filter(StudentSession_Table.sessionId == Session_Table.id) \
             .filter(StudentSession_Table.studentId == student_id) \
+            .filter(Session_Table.deletedAt == None) \
             .all()
 
     def get_student_attended_session_course_names(self, student_id, semester):
@@ -113,6 +114,7 @@ class User:
             .filter(StudentSession_Table.sessionId == Session_Table.id) \
             .filter(StudentSession_Table.studentId == student_id) \
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id) \
+            .filter(Session_Table.deletedAt == None) \
             .all()
 
     def get_average_time_in_course(self, student_id, course_id):

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -89,7 +89,7 @@ class User:
             .all()
 
 
-    def get_students_in_course(self, course_id):
+    def get_students_in_course(self, course_id, semester):
         return db_session.query(User_Table, func.count(distinct(StudentSession_Table.sessionId)))\
             .filter(Course_Table.id == course_id)\
             .filter(SessionCourses_Table.course_id == course_id)\
@@ -97,6 +97,7 @@ class User:
             .filter(StudentSession_Table.studentId == User_Table.id) \
             .filter(Session_Table.deletedAt == None) \
             .filter(Session_Table.id == StudentSession_Table.sessionId) \
+            .filter(Session_Table.semester_id == semester) \
             .group_by(User_Table.id)\
             .all()
 

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -89,7 +89,7 @@ class User:
 
 
     def get_students_in_course(self, course_id):
-        return db_session.query(User_Table, func.count(User_Table.id))\
+        return db_session.query(User_Table, func.count(distinct(StudentSession_Table.sessionId)))\
             .filter(Course_Table.id == course_id)\
             .filter(SessionCourses_Table.course_id == course_id)\
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id)\

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -76,6 +76,7 @@ class User:
             .filter(StudentSession_Table.sessionId == Session_Table.id)\
             .filter(Session_Table.semester_id == Semester_Table.id)\
             .filter(Semester_Table.id == semester_id)\
+            .filter(Session_Table.deletedAt == None) \
             .group_by(StudentSession_Table.sessionId)\
             .all()
 
@@ -106,6 +107,8 @@ class User:
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id) \
             .filter(StudentSession_Table.studentId == User_Table.id) \
             .filter(User_Table.id == student_id) \
+            .filter(Session_Table.id == StudentSession_Table.sessionId) \
+            .filter(Session_Table.deletedAt == None) \
             .all()
 
     def get_student(self, student_id):

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -100,6 +100,21 @@ class User:
             .group_by(User_Table.id)\
             .all()
 
+    def get_student_attended_sessions(self, student_id, semester):
+        return db_session.query(Session_Table, StudentSession_Table) \
+            .filter(Session_Table.semester_id == semester) \
+            .filter(StudentSession_Table.sessionId == Session_Table.id) \
+            .filter(StudentSession_Table.studentId == student_id) \
+            .all()
+
+    def get_student_attended_session_course_names(self, student_id, semester):
+        return db_session.query(StudentSession_Table, SessionCourses_Table, Session_Table) \
+            .filter(Session_Table.semester_id == semester) \
+            .filter(StudentSession_Table.sessionId == Session_Table.id) \
+            .filter(StudentSession_Table.studentId == student_id) \
+            .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id) \
+            .all()
+
     def get_average_time_in_course(self, student_id, course_id):
         return db_session.query(StudentSession_Table, User_Table) \
             .filter(Course_Table.id == course_id) \

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -102,21 +102,21 @@ class User:
             .all()
 
     def get_student_attended_sessions(self, student_id, semester):
-        return db_session.query(Session_Table, StudentSession_Table) \
+        return db_session.query(StudentSession_Table.sessionId) \
             .filter(Session_Table.semester_id == semester) \
             .filter(StudentSession_Table.sessionId == Session_Table.id) \
             .filter(StudentSession_Table.studentId == student_id) \
             .filter(Session_Table.deletedAt == None) \
-            .all()
+            .distinct()
 
     def get_student_attended_session_course_names(self, student_id, semester):
-        return db_session.query(StudentSession_Table, SessionCourses_Table, Session_Table) \
+        return db_session.query(StudentSession_Table.sessionId, SessionCourses_Table.course_id) \
             .filter(Session_Table.semester_id == semester) \
             .filter(StudentSession_Table.sessionId == Session_Table.id) \
             .filter(StudentSession_Table.studentId == student_id) \
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id) \
             .filter(Session_Table.deletedAt == None) \
-            .all()
+            .distinct()
 
     def get_average_time_in_course(self, student_id, course_id):
         return db_session.query(StudentSession_Table, User_Table) \

--- a/sciencelabs/db_repository/user_functions.py
+++ b/sciencelabs/db_repository/user_functions.py
@@ -93,7 +93,9 @@ class User:
             .filter(Course_Table.id == course_id)\
             .filter(SessionCourses_Table.course_id == course_id)\
             .filter(SessionCourses_Table.studentsession_id == StudentSession_Table.id)\
-            .filter(StudentSession_Table.studentId == User_Table.id)\
+            .filter(StudentSession_Table.studentId == User_Table.id) \
+            .filter(Session_Table.deletedAt == None) \
+            .filter(Session_Table.id == StudentSession_Table.sessionId) \
             .group_by(User_Table.id)\
             .all()
 

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -870,7 +870,7 @@ class ReportView(FlaskView):
         sessions_and_attendance = {}
         for lab_session in sessions:
             sessions_and_attendance[lab_session] = {
-                'attendance': self.session_.get_session_attendees_with_dup(course.id, lab_session.id)
+                'attendance': self.session_.get_session_attendees_for_course(course.id, lab_session.id)
 
             }
 
@@ -928,7 +928,7 @@ class ReportView(FlaskView):
             sub_list = [sess.date.strftime('%m/%d/%Y'), self._get_dayofweek((sess.date.weekday() + 1) % 7),
                         self._datetimeformatter(sess.schedStartTime) + ' - ' +
                         self._datetimeformatter(sess.schedEndTime)]
-            attendance_per_session = self.session_.get_session_attendees_with_dup(course_id, sess.id)
+            attendance_per_session = self.session_.get_session_attendees_for_course(course_id, sess.id)
             sub_list.append(len(attendance_per_session))
             total_attendance += len(attendance_per_session)
             my_list.append(sub_list)

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -753,8 +753,8 @@ class ReportView(FlaskView):
             unnamed_list = []
             duplicate_list = []
             for student in student_info:
-                student_session_attendance = len(self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER']))
-                student_session_course_names = len(self.user.get_student_attended_session_course_names(student.id, flask_session['SELECTED-SEMESTER']))
+                student_session_attendance = (self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER'])).count()
+                student_session_course_names = (self.user.get_student_attended_session_course_names(student.id, flask_session['SELECTED-SEMESTER'])).count()
                 # Subtracting these will either give us a zero (attendance is correct),
                 # a negative number (the student attended more than one course per session)
                 # or a positive number (the student attended a session but the course name wasn't recorded)
@@ -762,11 +762,9 @@ class ReportView(FlaskView):
 
                 if adjustment < 0:
                     duplicate_sessions -= adjustment
-                    duplicate_list.append(str(student.id) + " " + student.lastName + " " + str(adjustment))
 
                 if adjustment > 0:
                     unnamed_session += adjustment
-                    unnamed_list.append(str(student.id) + " " + student.lastName + " " + str(adjustment))
 
             anon_attendance = 0
             sessions = self.session_.get_closed_sessions(flask_session['SELECTED-SEMESTER'])

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -750,6 +750,8 @@ class ReportView(FlaskView):
             student_info = self.user.get_student_info(flask_session['SELECTED-SEMESTER'])
             duplicate_sessions = 0
             unnamed_session = 0
+            unnamed_list = []
+            duplicate_list = []
             for student in student_info:
                 student_session_attendance = len(self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER']))
                 student_session_course_names = len(self.user.get_student_attended_session_course_names(student.id, flask_session['SELECTED-SEMESTER']))
@@ -757,10 +759,14 @@ class ReportView(FlaskView):
                 # a negative number (the student attended more than one course per session)
                 # or a positive number (the student attended a session but the course name wasn't recorded)
                 adjustment = student_session_attendance - student_session_course_names
+
                 if adjustment < 0:
                     duplicate_sessions -= adjustment
+                    duplicate_list.append(str(student.id) + " " + student.lastName + " " + str(adjustment))
+
                 if adjustment > 0:
                     unnamed_session += adjustment
+                    unnamed_list.append(str(student.id) + " " + student.lastName + " " + str(adjustment))
 
         else:  # They must be a professor
             prof = self.user.get_user_by_username(flask_session['USERNAME'])

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -777,14 +777,14 @@ class ReportView(FlaskView):
         for course, course_user in course_info:
             courses_and_attendance[course] = {
                 'user': course_user,
-                'attendance': self.user.get_students_in_course(course.id)
+                'attendance': self.user.get_students_in_course(course.id, flask_session['SELECTED-SEMESTER'])
             }
 
         if course_viewer_info:
             for course, course_user in course_viewer_info:
                 courses_and_attendance[course] = {
                     'user': course_user,
-                    'attendance': self.user.get_students_in_course(course.id)
+                    'attendance': self.user.get_students_in_course(course.id, flask_session['SELECTED-SEMESTER'])
                 }
 
         return render_template('reports/course.html', **locals())
@@ -819,14 +819,14 @@ class ReportView(FlaskView):
         for course, course_user in course_info:
             courses_and_attendance[course] = {
                 'user': course_user,
-                'attendance': self.user.get_students_in_course(course.id)
+                'attendance': self.user.get_students_in_course(course.id, flask_session['SELECTED-SEMESTER'])
             }
 
         if course_viewer_info:
             for course, course_user in course_viewer_info:
                 courses_and_attendance[course] = {
                     'user': course_user,
-                    'attendance': self.user.get_students_in_course(course.id)
+                    'attendance': self.user.get_students_in_course(course.id, flask_session['SELECTED-SEMESTER'])
                 }
 
         ##### Adding data to CSV #####
@@ -874,10 +874,11 @@ class ReportView(FlaskView):
     @route('/course/<int:course_id>')
     def view_course(self, course_id):
         self.slc.check_roles_and_route(['Professor', 'Administrator', 'Academic Counselor'])
+        sem = self.schedule.get_semester(flask_session['SELECTED-SEMESTER'])
 
         course = self.courses.get_course(course_id)
         course_profs = self.courses.get_course_profs(course_id)
-        students = self.user.get_students_in_course(course_id)
+        students = self.user.get_students_in_course(course_id, flask_session['SELECTED-SEMESTER'])
 
         students_and_time = {}
         for student, attendance in students:
@@ -886,7 +887,7 @@ class ReportView(FlaskView):
                 'time': self.user.get_average_time_in_course(student.id, course.id)
             }
 
-        sessions = self.session_.get_sessions(course_id)
+        sessions = self.session_.get_sessions(course_id, sem.id)
         sessions_and_attendance = {}
         for lab_session in sessions:
             sessions_and_attendance[lab_session] = {
@@ -906,7 +907,7 @@ class ReportView(FlaskView):
         course = self.courses.get_course(course_id)
         course_profs = self.courses.get_course_profs(course_id)
 
-        sessions = self.session_.get_sessions(course_id)
+        sessions = self.session_.get_sessions(course_id, sem.id)
 
         student_sessions = self.session_.get_student_sessions_for_course(course_id, session_id)
 
@@ -939,7 +940,7 @@ class ReportView(FlaskView):
 
         my_list = [['Date', 'DOW', 'Time', 'Attendees']]
 
-        sessions = self.session_.get_sessions(course_id)
+        sessions = self.session_.get_sessions(course_id, sem.id)
         course = self.courses.get_course(course_id)
         csv_course_info = '{0}{1} ({2})'.format(course.dept, course.course_num, course.title)
 
@@ -973,7 +974,7 @@ class ReportView(FlaskView):
 
         my_list = [['First Name', 'Last Name', 'Sessions', 'Avg Time']]
 
-        students = self.user.get_students_in_course(course_id)
+        students = self.user.get_students_in_course(course_id, sem.id)
 
         total_attendance = 0
         total_time = 0

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -324,10 +324,6 @@ class ReportView(FlaskView):
                                                                                                        str(month) +
                                                                                                        '-31'))
 
-        # makes sure there is no division by zero
-        def divide_by_zero(num, den):
-            return num / den if den else 0
-
         total_attendance = 0
         for schedule in schedule_info:
             for session_info in monthly_sessions:
@@ -349,7 +345,7 @@ class ReportView(FlaskView):
                             self._datetimeformatter(schedule.startTime) + ' - ' +
                             self._datetimeformatter(schedule.endTime),
                             total_attendance_per_schedule,
-                            str(round((divide_by_zero(total_attendance_per_schedule, total_attendance)) * 100,
+                            str(round((self.divide_by_zero(total_attendance_per_schedule, total_attendance)) * 100,
                                       1)) + '%'])
 
         unscheduled_sessions = self.session_.get_unscheduled_sessions(year, term)
@@ -360,7 +356,7 @@ class ReportView(FlaskView):
             total_attendance += total_unscheduled
 
         my_list.append(['Unscheduled Sessions', '', '', total_unscheduled,
-                        str(round((divide_by_zero(total_unscheduled, total_attendance)) * 100, 1)) + '%'])
+                        str(round((self.divide_by_zero(total_unscheduled, total_attendance)) * 100, 1)) + '%'])
 
         my_list.append(['', '', 'Total', total_attendance])
 
@@ -1052,11 +1048,11 @@ class ReportView(FlaskView):
                 if times.timeOut and times.timeIn:
                     avg_time += (((times.timeOut - times.timeIn).total_seconds()) / 60)
 
-            total_time += avg_time / len(time)
-            sub_list.append(str(round(avg_time / len(time))) + ' min')
+            total_time += self.divide_by_zero(avg_time, len(time))
+            sub_list.append(str(round(self.divide_by_zero(avg_time, len(time)))) + ' min')
             my_list.append(sub_list)
 
-        my_list.append(['', 'Total:', total_attendance, total_time / index])
+        my_list.append(['', 'Total:', total_attendance, self.divide_by_zero(total_time, index)])
 
         return self.export_csv(my_list, csv_name)
 
@@ -1127,3 +1123,7 @@ class ReportView(FlaskView):
         flask_session['SELECTED-SEMESTER'] = int(sem.id)
         # Lets the session know it was modified
         flask_session.modified = True
+
+    # makes sure there is no division by zero
+    def divide_by_zero(self, num, den):
+        return num / den if den else 0

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -768,6 +768,12 @@ class ReportView(FlaskView):
                     unnamed_session += adjustment
                     unnamed_list.append(str(student.id) + " " + student.lastName + " " + str(adjustment))
 
+            anon_attendance = 0
+            sessions = self.session_.get_closed_sessions(flask_session['SELECTED-SEMESTER'])
+            for sess in sessions:
+                session_info = self.session_.get_session(sess.id)
+                anon_attendance += session_info.anonStudents
+
         else:  # They must be a professor
             prof = self.user.get_user_by_username(flask_session['USERNAME'])
             course_info = self.courses.get_selected_prof_course_info(flask_session['SELECTED-SEMESTER'], prof.id)

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -745,8 +745,22 @@ class ReportView(FlaskView):
                 or ('ADMIN-VIEWER' in flask_session.keys() and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
 
             course_info = self.courses.get_selected_course_info(flask_session['SELECTED-SEMESTER'])
-            other_info = self.courses.get_other_info(flask_session['SELECTED-SEMESTER'])
             course_viewer_info = None
+
+            student_info = self.user.get_student_info(flask_session['SELECTED-SEMESTER'])
+            duplicate_sessions = 0
+            unnamed_session = 0
+            for student in student_info:
+                student_session_attendance = len(self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER']))
+                student_session_course_names = len(self.user.get_student_attended_session_course_names(student.id, flask_session['SELECTED-SEMESTER']))
+                # Subtracting these will either give us a zero (attendance is correct),
+                # a negative number (the student attended more than one course per session)
+                # or a positive number (the student attended a session but the course name wasn't recorded)
+                adjustment = student_session_attendance - student_session_course_names
+                if adjustment < 0:
+                    duplicate_sessions -= adjustment
+                if adjustment > 0:
+                    unnamed_session += adjustment
 
         else:  # They must be a professor
             prof = self.user.get_user_by_username(flask_session['USERNAME'])

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -38,7 +38,10 @@ class ReportView(FlaskView):
 
         student_info = self.user.get_student_info(flask_session['SELECTED-SEMESTER'])
 
-        student_and_attendance = {student: len(self.user.get_unique_sessions_attended(student.id, flask_session['SELECTED-SEMESTER'])) for student in student_info}
+        student_and_attendance = {
+            student: len(self.user.get_unique_sessions_attended(student.id, flask_session['SELECTED-SEMESTER']))
+            for student in student_info
+        }
 
         return render_template('reports/student.html', **locals())
 
@@ -54,22 +57,29 @@ class ReportView(FlaskView):
         # The last check in the following if is to see if we are viewing the prof role, but not a specific prof user
         if 'Administrator' in flask_session['USER-ROLES'] \
                 or 'Academic Counselor' in flask_session['USER-ROLES'] \
-                or ('Professor' in flask_session['USER-ROLES'] and flask_session['NAME'] and self.courses.student_is_in_prof_course(student_id, viewer.id)) \
-                or ('ADMIN-VIEWER' in flask_session.keys() and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
+                or ('Professor' in flask_session['USER-ROLES'] and flask_session['NAME']
+                    and self.courses.student_is_in_prof_course(student_id, viewer.id)) \
+                or ('ADMIN-VIEWER' in flask_session.keys()
+                    and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
 
             role_can_view = True
             if self.user.get_student_attendance(student_id, flask_session['SELECTED-SEMESTER']):
-                student_info, attendance = self.user.get_student_attendance(student_id, flask_session['SELECTED-SEMESTER'])
+                student_info, attendance = self.user.get_student_attendance(student_id,
+                                                                            flask_session['SELECTED-SEMESTER'])
             else:
-                self.slc.set_alert('info','Notice: ' + student.firstName + ' ' + student.lastName + ' has not attended any labs for ' + sem.term + ' ' + str(year) + '')
+                self.slc.set_alert('info', 'Notice: ' + student.firstName + ' ' + student.lastName
+                                   + ' has not attended any labs for ' + sem.term + ' ' + str(year) + '')
 
                 attendance = 0
             total_sessions = self.session_.get_closed_sessions(flask_session['SELECTED-SEMESTER'])
             courses = self.user.get_student_courses(student_id, flask_session['SELECTED-SEMESTER'])
             sessions = self.user.get_studentsession(student_id, flask_session['SELECTED-SEMESTER'])
-            sessions_attended = len(self.user.get_unique_sessions_attended(student_id, flask_session['SELECTED-SEMESTER']))
+            sessions_attended = len(
+                self.user.get_unique_sessions_attended(student_id, flask_session['SELECTED-SEMESTER']))
 
-            course_and_avg_time = {course: self.user.get_average_time_in_course(student.id, course.id) for course in courses}
+            course_and_avg_time = {
+                course: self.user.get_average_time_in_course(student.id, course.id) for course in courses
+            }
 
             sessions_and_courses = {}
             for studentsession, lab_session in sessions:
@@ -98,7 +108,8 @@ class ReportView(FlaskView):
         my_list = [['Last', 'First', 'Email', 'Attendance']]
 
         for student in self.user.get_student_info(flask_session['SELECTED-SEMESTER']):
-            my_list.append([student.lastName, student.firstName, student.email, len(self.user.get_unique_sessions_attended(student.id, flask_session['SELECTED-SEMESTER']))])
+            my_list.append([student.lastName, student.firstName, student.email, len(
+                self.user.get_unique_sessions_attended(student.id, flask_session['SELECTED-SEMESTER']))])
 
         return self.export_csv(my_list, csv_name)
 
@@ -147,7 +158,8 @@ class ReportView(FlaskView):
         unscheduled_sessions_and_attendance = {}
         for unscheduled_session in unscheduled_sessions:
             unscheduled_sessions_and_attendance[unscheduled_session] = {
-                'attendance': len(self.user.get_session_students(unscheduled_session.id)), # I don't believe this is ever used 6/1/2021
+                'attendance': len(self.user.get_session_students(unscheduled_session.id)),
+                # I don't believe attendance is ever used 6/1/2021
                 'unscheduled-attendance': self.session_.get_unscheduled_unique_attendance(unscheduled_session.id)
             }
 
@@ -270,7 +282,10 @@ class ReportView(FlaskView):
         schedule_info = self.schedule.get_yearly_schedule_tab_info(selected_year, term)
         sessions = self.session_.get_semester_closed_sessions(selected_year, term)
         unscheduled_sessions = self.session_.get_unscheduled_sessions(selected_year, term)
-        unscheduled_sessions_and_attendance = {unscheduled_session: len(self.user.get_session_students(unscheduled_session.id)) for unscheduled_session in unscheduled_sessions}
+        unscheduled_sessions_and_attendance = {
+            unscheduled_session: len(self.user.get_session_students(unscheduled_session.id)) for unscheduled_session in
+            unscheduled_sessions
+        }
         monthly_sessions = self.session_.get_monthly_sessions((str(year) + '-' + str(month) + '-01'), (str(year) + '-' +
                                                                                                        str(month) +
                                                                                                        '-31'))
@@ -309,6 +324,10 @@ class ReportView(FlaskView):
                                                                                                        str(month) +
                                                                                                        '-31'))
 
+        # makes sure there is no division by zero
+        def divide_by_zero(num, den):
+            return num / den if den else 0
+
         total_attendance = 0
         for schedule in schedule_info:
             for session_info in monthly_sessions:
@@ -330,7 +349,8 @@ class ReportView(FlaskView):
                             self._datetimeformatter(schedule.startTime) + ' - ' +
                             self._datetimeformatter(schedule.endTime),
                             total_attendance_per_schedule,
-                            str(round((total_attendance_per_schedule/total_attendance)*100, 1)) + '%'])
+                            str(round((divide_by_zero(total_attendance_per_schedule, total_attendance)) * 100,
+                                      1)) + '%'])
 
         unscheduled_sessions = self.session_.get_unscheduled_sessions(year, term)
         total_unscheduled = 0
@@ -340,7 +360,7 @@ class ReportView(FlaskView):
             total_attendance += total_unscheduled
 
         my_list.append(['Unscheduled Sessions', '', '', total_unscheduled,
-                        str(round((total_unscheduled / total_attendance) * 100, 1)) + '%'])
+                        str(round((divide_by_zero(total_unscheduled, total_attendance)) * 100, 1)) + '%'])
 
         my_list.append(['', '', 'Total', total_attendance])
 
@@ -598,7 +618,10 @@ class ReportView(FlaskView):
         tutors = self.session_.get_session_tutors(session_id)
         student_session_list = self.session_.get_student_session_from_session(session_id)
         session_courses = self.session_.get_session_course_codes(session_id)
-        session_courses_and_attendance = {course: self.session_.get_course_code_attendance(session_id, course.id) for course in session_courses}
+        session_courses_and_attendance = {
+            course: self.session_.get_course_code_attendance(session_id, course.id) for
+            course in session_courses
+        }
         opener = None
         if session_info.openerId:
             opener = self.user.get_user(session_info.openerId)
@@ -645,7 +668,8 @@ class ReportView(FlaskView):
                 time_in = 'N/A'
             if not time_out:
                 time_out = 'N/A'
-            my_list.append([student.lastName, student.firstName, student.email, time_in, time_out, virtual, seat_number])
+            my_list.append(
+                [student.lastName, student.firstName, student.email, time_in, time_out, virtual, seat_number])
 
         return self.export_csv(my_list, csv_name)
 
@@ -659,7 +683,6 @@ class ReportView(FlaskView):
         lab_acronym = ''
         for letter in app.config['LAB_TITLE'].split():
             lab_acronym += letter[0]
-
 
         csv_name = '{0}_{1}_RoomGroupReport'.format(sessions[0].date.strftime('%m-%d-%Y'), lab_acronym)
 
@@ -692,7 +715,8 @@ class ReportView(FlaskView):
                     time_in = 'N/A'
                 if not time_out:
                     time_out = 'N/A'
-                my_list.append([student.lastName, student.firstName, student.email, time_in, time_out, virtual, seat_number])
+                my_list.append(
+                    [student.lastName, student.firstName, student.email, time_in, time_out, virtual, seat_number])
 
         return self.export_csv(my_list, csv_name)
 
@@ -741,8 +765,10 @@ class ReportView(FlaskView):
         semester = self.schedule.get_semester(flask_session['SELECTED-SEMESTER'])
 
         # The last check in the following if is to see if we are viewing the prof role, but not a specific prof user
-        if 'Administrator' in flask_session['USER-ROLES'] or 'Academic Counselor' in flask_session['USER-ROLES']\
-                or ('ADMIN-VIEWER' in flask_session.keys() and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
+        if 'Administrator' in flask_session['USER-ROLES'] \
+                or 'Academic Counselor' in flask_session['USER-ROLES'] \
+                or ('ADMIN-VIEWER' in flask_session.keys()
+                    and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
 
             course_info = self.courses.get_selected_course_info(flask_session['SELECTED-SEMESTER'])
             course_viewer_info = None
@@ -750,11 +776,11 @@ class ReportView(FlaskView):
             student_info = self.user.get_student_info(flask_session['SELECTED-SEMESTER'])
             duplicate_sessions = 0
             unnamed_session = 0
-            unnamed_list = []
-            duplicate_list = []
             for student in student_info:
-                student_session_attendance = (self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER'])).count()
-                student_session_course_names = (self.user.get_student_attended_session_course_names(student.id, flask_session['SELECTED-SEMESTER'])).count()
+                student_session_attendance = (self.user.get_student_attended_sessions(student.id,
+                                                flask_session['SELECTED-SEMESTER'])).count()
+                student_session_course_names = (self.user.get_student_attended_session_course_names(student.id,
+                                                flask_session['SELECTED-SEMESTER'])).count()
                 # Subtracting these will either give us a zero (attendance is correct),
                 # a negative number (the student attended more than one course per session)
                 # or a positive number (the student attended a session but the course name wasn't recorded)
@@ -775,7 +801,8 @@ class ReportView(FlaskView):
         else:  # They must be a professor
             prof = self.user.get_user_by_username(flask_session['USERNAME'])
             course_info = self.courses.get_selected_prof_course_info(flask_session['SELECTED-SEMESTER'], prof.id)
-            course_viewer_info = self.courses.get_selected_course_viewer_info(flask_session['SELECTED-SEMESTER'], prof.id)
+            course_viewer_info = self.courses.get_selected_course_viewer_info(flask_session['SELECTED-SEMESTER'],
+                                                                              prof.id)
 
         courses_and_attendance = {}
         for course, course_user in course_info:
@@ -802,9 +829,13 @@ class ReportView(FlaskView):
         csv_name = '%s%s_%s_CourseReport' % (semester.term, semester.year, lab_acronym)
 
         csv_data = []
-        csv_data.append(['Course', 'Section', 'Professor', 'Total Attendance', 'Unique Attendance', '% of Lab Attendance'])
+        csv_data.append(
+            ['Course', 'Section', 'Professor', 'Total Attendance', 'Unique Attendance', '% of Lab Attendance'])
 
         ##### Gathering data #####
+        duplicate_sessions = 0
+        unnamed_session = 0
+        anon_attendance = 0
         # The last check in the following if is to see if we are viewing the prof role, but not a specific prof user
         if 'Administrator' in flask_session['USER-ROLES'] or 'Academic Counselor' in flask_session['USER-ROLES'] \
                 or (
@@ -812,6 +843,28 @@ class ReportView(FlaskView):
 
             course_info = self.courses.get_selected_course_info(flask_session['SELECTED-SEMESTER'])
             course_viewer_info = None
+
+            student_info = self.user.get_student_info(flask_session['SELECTED-SEMESTER'])
+            for student in student_info:
+                student_session_attendance = (
+                    self.user.get_student_attended_sessions(student.id, flask_session['SELECTED-SEMESTER'])).count()
+                student_session_course_names = (self.user.get_student_attended_session_course_names(student.id,
+                                                flask_session['SELECTED-SEMESTER'])).count()
+                # Subtracting these will either give us a zero (attendance is correct),
+                # a negative number (the student attended more than one course per session)
+                # or a positive number (the student attended a session but the course name wasn't recorded)
+                adjustment = student_session_attendance - student_session_course_names
+
+                if adjustment < 0:
+                    duplicate_sessions -= adjustment
+
+                if adjustment > 0:
+                    unnamed_session += adjustment
+
+            sessions = self.session_.get_closed_sessions(flask_session['SELECTED-SEMESTER'])
+            for sess in sessions:
+                session_info = self.session_.get_session(sess.id)
+                anon_attendance += session_info.anonStudents
 
         else:  # They must be a professor
             prof = self.user.get_user_by_username(flask_session['USERNAME'])
@@ -848,9 +901,15 @@ class ReportView(FlaskView):
             csv_data.append([course.title + " ({0}{1})".format(course.dept, course.course_num), course.section,
                              "{0} {1}".format(info['user'].firstName, info['user'].lastName), course_total_attendance,
                              len(info['attendance']),
-                             "{0}%".format(round((course_total_attendance/total_attendance)*100, 2))])
-
-        csv_data.append(['', '', 'Total', total_attendance, total_unique_attendance])
+                             "{0}%".format(round((len(info['attendance']) / course.num_attendees) * 100, 2))])
+        if 'Administrator' in flask_session['USER-ROLES'] \
+            or 'Academic Counselor' in flask_session['USER-ROLES'] or \
+                ('ADMIN-VIEWER' in flask_session.keys() and flask_session['ADMIN-VIEWER'] and not flask_session['NAME']):
+            csv_data.append(['', '', 'Other', unnamed_session + anon_attendance])
+            csv_data.append(['', '', 'Total ' + '(' + str(duplicate_sessions) + ' duplicate sessions)',
+                             total_attendance + unnamed_session + anon_attendance, total_unique_attendance])
+        else:
+            csv_data.append(['', '', 'Total', total_attendance, total_unique_attendance])
 
         return self.export_csv(csv_data, csv_name)
 
@@ -954,8 +1013,8 @@ class ReportView(FlaskView):
                         self._datetimeformatter(sess.schedStartTime) + ' - ' +
                         self._datetimeformatter(sess.schedEndTime)]
             attendance_per_session = self.session_.get_session_attendees_for_course(course_id, sess.id)
-            sub_list.append(len(attendance_per_session))
-            total_attendance += len(attendance_per_session)
+            sub_list.append(attendance_per_session.count())
+            total_attendance += attendance_per_session.count()
             my_list.append(sub_list)
 
         my_list.append(['', '', 'Total', total_attendance])
@@ -991,13 +1050,13 @@ class ReportView(FlaskView):
             avg_time = 0
             for times, user in time:
                 if times.timeOut and times.timeIn:
-                    avg_time += (((times.timeOut - times.timeIn).total_seconds())/60)
+                    avg_time += (((times.timeOut - times.timeIn).total_seconds()) / 60)
 
-            total_time += avg_time/len(time)
-            sub_list.append(str(round(avg_time/len(time))) + ' min')
+            total_time += avg_time / len(time)
+            sub_list.append(str(round(avg_time / len(time))) + ' min')
             my_list.append(sub_list)
 
-        my_list.append(['', 'Total:', total_attendance, total_time/index])
+        my_list.append(['', 'Total:', total_attendance, total_time / index])
 
         return self.export_csv(my_list, csv_name)
 
@@ -1068,4 +1127,3 @@ class ReportView(FlaskView):
         flask_session['SELECTED-SEMESTER'] = int(sem.id)
         # Lets the session know it was modified
         flask_session.modified = True
-

--- a/sciencelabs/reports/__init__.py
+++ b/sciencelabs/reports/__init__.py
@@ -147,7 +147,7 @@ class ReportView(FlaskView):
         unscheduled_sessions_and_attendance = {}
         for unscheduled_session in unscheduled_sessions:
             unscheduled_sessions_and_attendance[unscheduled_session] = {
-                'attendance': len(self.user.get_session_students(unscheduled_session.id)),
+                'attendance': len(self.user.get_session_students(unscheduled_session.id)), # I don't believe this is ever used 6/1/2021
                 'unscheduled-attendance': self.session_.get_unscheduled_unique_attendance(unscheduled_session.id)
             }
 

--- a/sciencelabs/templates/reports/course.html
+++ b/sciencelabs/templates/reports/course.html
@@ -104,15 +104,15 @@
                             {% endfor %}
                         </tbody>
                         <tfoot>
-                            {% if other_info %}
+                            {% if unnamed_session != 0 %}
                                 <tr>
-                                    <th class="no-border-top" colspan="4">Other</th>
-                                    <th class="no-border-top">{{ other_info|length }}</th>
+                                    <th class="no-border-top" colspan="4">Courses Attended Without Names</th>
+                                    <th class="no-border-top">{{ unnamed_session }}</th>
                                 </tr>
                             {% endif %}
                             <tr>
-                                <th class="no-border-top" colspan="4">Total</th>
-                                <th class="no-border-top">{{ total_attendance[0] + other_info|length }}</th>
+                                <th class="no-border-top" colspan="4">Total ({{ duplicate_sessions }} Session Duplicates)</th>
+                                <th class="no-border-top">{{ total_attendance[0] + unnamed_session }}</th>
                                 <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
                             </tr>
                         </tfoot>

--- a/sciencelabs/templates/reports/course.html
+++ b/sciencelabs/templates/reports/course.html
@@ -106,13 +106,13 @@
                         <tfoot>
                             {% if unnamed_session != 0 %}
                                 <tr>
-                                    <th class="no-border-top" colspan="4">Courses Attended Without Names</th>
-                                    <th class="no-border-top">{{ unnamed_session }}</th>
+                                    <th class="no-border-top" colspan="4">Other</th>
+                                    <th class="no-border-top">{{ unnamed_session + anon_attendance }}</th>
                                 </tr>
                             {% endif %}
                             <tr>
                                 <th class="no-border-top" colspan="4">Total ({{ duplicate_sessions }} Session Duplicates)</th>
-                                <th class="no-border-top">{{ total_attendance[0] + unnamed_session }}</th>
+                                <th class="no-border-top">{{ total_attendance[0] + unnamed_session + anon_attendance }}</th>
                                 <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
                             </tr>
                         </tfoot>
@@ -152,6 +152,12 @@
                     <p class="card-text">
                         To view course report data from a different term, choose an option from the term menu in the
                         upper right hand corner of the page and press the <span class="button-labels">Set</span> button.
+                    </p>
+
+                    <p class="card-text">
+                        The <Strong>Other</Strong> row at the bottom of the course report shows the anonymous
+                        attendance as well as attendance where students sign in to a session
+                        but forget to select which course they are signing in for (so the course is not recorded).
                     </p>
 
                     <p class="card-text">

--- a/sciencelabs/templates/reports/course.html
+++ b/sciencelabs/templates/reports/course.html
@@ -120,7 +120,10 @@
                 {% else %}
                     <p>No {{ lab_title }} courses for {{ semester.term }} {{ semester.year }}</p>
                 {% endif %}
-
+                dup
+                {{ duplicate_list }} <br>
+                unnamed
+                {{ unnamed_list }}
             </form>
         </div>
         <div class="col-md-4">

--- a/sciencelabs/templates/reports/course.html
+++ b/sciencelabs/templates/reports/course.html
@@ -104,26 +104,29 @@
                             {% endfor %}
                         </tbody>
                         <tfoot>
-                            {% if unnamed_session != 0 %}
+                            {% if unnamed_session or unnamed_session == 0%}
                                 <tr>
                                     <th class="no-border-top" colspan="4">Other</th>
                                     <th class="no-border-top">{{ unnamed_session + anon_attendance }}</th>
                                 </tr>
+                                <tr>
+                                    <th class="no-border-top" colspan="4">Total ({{ duplicate_sessions }} Session Duplicates)</th>
+                                    <th class="no-border-top">{{ total_attendance[0] + unnamed_session + anon_attendance }}</th>
+                                    <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
+                                </tr>
+                            {% else %}
+                                <tr>
+                                    <th class="no-border-top" colspan="4">Total</th>
+                                    <th class="no-border-top">{{ total_attendance[0] }}</th>
+                                    <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
+                                </tr>
                             {% endif %}
-                            <tr>
-                                <th class="no-border-top" colspan="4">Total ({{ duplicate_sessions }} Session Duplicates)</th>
-                                <th class="no-border-top">{{ total_attendance[0] + unnamed_session + anon_attendance }}</th>
-                                <th class="no-border-top">{{ total_unique_attendance[0] }}</th>
-                            </tr>
+
                         </tfoot>
                     </table>
                 {% else %}
                     <p>No {{ lab_title }} courses for {{ semester.term }} {{ semester.year }}</p>
                 {% endif %}
-                dup
-                {{ duplicate_list }} <br>
-                unnamed
-                {{ unnamed_list }}
             </form>
         </div>
         <div class="col-md-4">

--- a/sciencelabs/templates/reports/term.html
+++ b/sciencelabs/templates/reports/term.html
@@ -46,7 +46,7 @@
                                                     {% if total_unique_unscheduled_attendance.append(total_unique_unscheduled_attendance.pop() + unscheduled_attendance[1]) %}{% endif %}
                                                 {% endif %}
                                             {% endfor %}
-                                            {% if total_unscheduled.append(total_unscheduled.pop() + info['attendance'] + sessions.anonStudents) %}{% endif %}
+                                            {% if total_unscheduled.append(total_unscheduled.pop() + info['unscheduled-attendance'] | length + sessions.anonStudents) %}{% endif %}
                                         {% endfor %}
                                     {% endif %}
                                     {% set total_anon_attendance = [0] %}
@@ -173,8 +173,8 @@
                         <td>{{ sessions.date.strftime('%m/%d/%Y') }}</td>
                         <td>{{ sessions.startTime|datetimeformat }}</td>
                         <td>{{ sessions.endTime|datetimeformat }}</td>
-                        <td>{{ info['attendance'] + sessions.anonStudents }}</td>
-                        {% if total_unscheduled.append(total_unscheduled.pop() + info['attendance'] + sessions.anonStudents) %}{% endif %}
+                        <td>{{ info['unscheduled-attendance'] | length + sessions.anonStudents }}</td>
+                        {% if total_unscheduled.append(total_unscheduled.pop() + info['unscheduled-attendance'] | length + sessions.anonStudents) %}{% endif %}
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/sciencelabs/templates/reports/view_course.html
+++ b/sciencelabs/templates/reports/view_course.html
@@ -60,12 +60,12 @@
                         {% set attendance_per_session = info['attendance'] %}
                         <td>
                             {% if 'Administrator' in session['USER-ROLES'] or 'Academic Counselor' in session['USER-ROLES'] %}
-                                <a class="no-decoration" href="{{ url_for('ReportView:view_session', session_id=lab_session.id) }}">{{ attendance_per_session|length }}</a>
+                                <a class="no-decoration" href="{{ url_for('ReportView:view_session', session_id=lab_session.id) }}">{{ attendance_per_session.count() }}</a>
                             {% else %}
-                                <a class="no-decoration" href="{{ url_for('ReportView:view_course_session', session_id=lab_session.id, course_id=course.id, date=lab_session.date.strftime('%Y-%m-%d')) }}">{{ attendance_per_session|length }}</a>
+                                <a class="no-decoration" href="{{ url_for('ReportView:view_course_session', session_id=lab_session.id, course_id=course.id, date=lab_session.date.strftime('%Y-%m-%d')) }}">{{ attendance_per_session.count() }}</a>
                             {% endif %}
                         </td>
-                    {% if total_attendees.append(total_attendees.pop() + attendance_per_session|length) %}{% endif %}
+                    {% if total_attendees.append(total_attendees.pop() + attendance_per_session.count()) %}{% endif %}
                     </tr>
                     {% endfor %}
                     </tbody>

--- a/sciencelabs/templates/reports/view_session.html
+++ b/sciencelabs/templates/reports/view_session.html
@@ -25,6 +25,18 @@
 
                 <div class="form-row">
                     <div class="form-group col-md-6">
+
+                        {% if session_info.deletedAt %}
+                            <ul class="no-bullet">
+                                <li><b><span class="button-labels" id="red">Session Deleted On:</span></b></li>
+                                <li>
+                                    <ul class="no-bullet">
+                                        <li>{{ session_info.deletedAt.strftime('%B %d, %Y') }}</li>
+                                    </ul>
+                                </li>
+                            </ul>
+                        {% endif %}
+
                         <ul class="no-bullet">
                             <li><b>Date:</b></li>
                             <li>

--- a/sciencelabs/templates/reports/view_student.html
+++ b/sciencelabs/templates/reports/view_student.html
@@ -179,6 +179,9 @@
                                     {% else %}
                                         {{ info['session'].name }}
                                     {% endif %}
+                                    {% if info['session'].deletedAt is not none %}
+                                        <span id="red" class="button-labels">Deleted</span>
+                                    {% endif %}
                                 </td>
                                 <td>
                                     {% for course in info['courses'] %}


### PR DESCRIPTION
## Description

The attendance totals on the different report tabs were not all the same. I made changes to a lot of queries to account for deleted sessions, sessions signed in without a course name, anonymous sign ins, and sessions where a student signed in for multiple classes. I Also made it so if a student signs in and out of a session more than one time, it only counts as one visit.

Fixes #212 

## Size and Type of change

Delete any of these you don't use.

- Medium Change - 2+ people need to review this

- Bug fix
- New feature

## How Has This Been Tested?

I made a lot of test sessions locally and observed the behavior to the attendance when a student would sign in once, more than once, for more than one class per session. I also observed what would happen when a session was deleted and how that affected the attendances. I then made changes to the code. I also checked out my branch to prod and viewed different semesters with my code and made code changes based on what I saw. Everything seems to line up now between the tabs. I added a duplicated session number to the course report page total that can be subtracted from the actual total to make the attendance agree with the other pages.

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)