### PR TITLE
Allows For User To See All Sessions

### DIFF
--- a/sciencelabs/db_repository/session_functions.py
+++ b/sciencelabs/db_repository/session_functions.py
@@ -146,6 +146,13 @@ class Session:
             .order_by(Session_Table.date) \
             .all()
 
+    def get_all_deleted_sessions(self, semester_id):
+        return db_session.query(Session_Table) \
+            .filter(Session_Table.semester_id == semester_id) \
+            .filter(Session_Table.deletedAt != None) \
+            .order_by(Session_Table.date) \
+            .all()
+
     def get_session(self, session_id):
         return db_session.query(Session_Table)\
             .filter(Session_Table.id == session_id)\

--- a/sciencelabs/sessions/__init__.py
+++ b/sciencelabs/sessions/__init__.py
@@ -60,6 +60,7 @@ class SessionView(FlaskView):
         sessions = self.session.get_deleted_sessions(flask_session['SELECTED-SEMESTER'])
         semester = self.schedule.get_semester(flask_session['SELECTED-SEMESTER'])
         sessions_and_tutors = {deleted_session: self.session.get_session_tutors(deleted_session.id) for deleted_session in sessions}
+        include_all_sessions = False
         return render_template('sessions/restore_session.html', **locals())
 
     @route('/edit/<int:session_id>')
@@ -909,6 +910,14 @@ class SessionView(FlaskView):
         except Exception as error:
             self.slc.set_alert('danger', 'Failed to restore session: {0}'.format(str(error)))
             return redirect(url_for('SessionView:deleted'))
+
+    def deleted_all(self):
+        sessions = self.session.get_all_deleted_sessions(flask_session['SELECTED-SEMESTER'])
+        semester = self.schedule.get_semester(flask_session['SELECTED-SEMESTER'])
+        sessions_and_tutors = {deleted_session: self.session.get_session_tutors(deleted_session.id) for deleted_session
+                               in sessions}
+        include_all_sessions = True
+        return render_template('sessions/restore_session.html', **locals())
 
     # START OF ROOM GROUP UPDATES #
 

--- a/sciencelabs/static/assets/css/sciencelabs.css
+++ b/sciencelabs/static/assets/css/sciencelabs.css
@@ -608,6 +608,12 @@ select:invalid {
     cursor: pointer;
 }
 
+.session-selector {
+    align-items: center;
+    display: flex;
+    justify-content: space-between;
+}
+
 #show-hide {
     background-color: #0F2C52;
     border-color: #0F2C52;

--- a/sciencelabs/templates/sessions/restore_session.html
+++ b/sciencelabs/templates/sessions/restore_session.html
@@ -2,8 +2,13 @@
 
 {% block header %}
     <div class="header card">
-        <div class="card-body">
-            <p class="card-text">Deleted Sessions for {{ semester.term }} {{ semester.year }}</p>
+        <div class="card-body session-selector">
+            Deleted Sessions for {{ semester.term }} {{ semester.year }}
+            {% if include_all_sessions == False %}
+                <a href='{{ url_for('SessionView:deleted_all') }}' id="blue" class="session-selector btn btn-primary border-white">Show All Sessions</a>
+            {% else %}
+                <a href='{{ url_for('SessionView:deleted') }}' id="blue" class="session-selector btn btn-primary border-white">Show Only Closed Sessions</a>
+            {% endif %}
         </div>
     </div>
 {% endblock %}


### PR DESCRIPTION
## Description

Sessions that were deleted that were never opened and closed didn't appear as an option for restoring before. Now there is an option to show all sessions (not just closed ones).

Fixes #211 

## Size and Type of change

Delete any of these you don't use.

- Small Change - 1 person needs to review this

- Bug fix
- New feature

## How Has This Been Tested?

I viewed the page in different browsers and it looked good all around. You can swap between views and restore any deleted session. Deleting an unclosed session has the session appear in the "show all sessions" view in the restore page

## Checklist:

Only check what applies and what you have done.

- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] I have tested on multiple browsers (Chrome, Firefox, Safari, IE suite)